### PR TITLE
Release 0.1.27: no-op when discovery finds no files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Changed
 
+## [0.1.27] - 2026-05-18
+
+### Fixed
+
+- `CHANGELOG.md`: add the missing `[0.1.26]` release reference link at the bottom so version anchors
+  match the other shipped releases.
+
 ## [0.1.26] - 2026-05-18
 
 ### Added
@@ -75,5 +82,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 - README `MAX_RETRY_ATTEMPTS` default matches `src/utils/constants.util.ts` (`3`).
 
+[0.1.27]: https://github.com/NivaldoFarias/translate-react/releases/tag/v0.1.27
+[0.1.26]: https://github.com/NivaldoFarias/translate-react/releases/tag/v0.1.26
 [0.1.25]: https://github.com/NivaldoFarias/translate-react/releases/tag/v0.1.25
 [0.1.24]: https://github.com/NivaldoFarias/translate-react/releases/tag/v0.1.24

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -25,6 +25,7 @@ Detailed breakdown of the translation workflow: execution stages, data flow, and
   - [Translation Phase](#translation-phase)
 - [Data Structures](#data-structures)
 - [Error Recovery](#error-recovery)
+  - [Empty discovery](#empty-discovery-no-files-to-translate)
 
 ## Overview
 
@@ -72,10 +73,10 @@ Order in [`RunnerService.run()`](../src/services/runner/runner.service.ts), then
 2. `verifyPermissions()`: wraps `verifyTokenPermissions` on fork and upstream
 3. `syncFork()`: `forkExists()`, then `isForkSynced()` / `syncFork` if behind
 4. `fetchRepositoryTree()`: upstream tree (markdown + `src/` filter applied in GitHub layer) and translation guidelines
-5. `fetchFilesToTranslate()`: unless `state.filesToTranslate` is already populated (unusual outside tests), runs `FileDiscoveryManager.discoverFiles`
-6. `processInBatches()`: per-file branch, translate, commit, PR
+5. `fetchFilesToTranslate()`: unless `state.filesToTranslate` is already populated (unusual outside tests), runs `FileDiscoveryManager.discoverFiles`; returns `false` when that pipeline yields no candidates, so the next step is skipped
+6. `processInBatches()`: when step 5 returned `true`, per-file branch, translate, commit, PR; omitted when there is nothing to translate (workflow still completes successfully)
 7. `updateIssueWithResults()`: `PRManager.updateIssue` → `GitHubService.commentCompiledResultsOnIssue` (see [Stage 6: Progress Reporting](#stage-6-progress-reporting))
-8. `printFinalStatistics()`: returns counts to the caller; `main` logs them and exits successfully when no exception was thrown
+8. `printFinalStatistics()`: returns counts to the caller (zeros when step 6 was skipped); `main` logs them and exits successfully when no exception was thrown
 
 ## Operating translate-react (forks)
 
@@ -312,3 +313,7 @@ flowchart TD
 - **Per file:** On failure after branch work, `cleanupFailedTranslation` deletes the translation branch when possible; the result is stored with `error` set; processing continues with the next file unless the circuit breaker trips.
 - **Circuit breaker:** After `MAX_CONSECUTIVE_FAILURES` consecutive failures, `processFile` throws before starting the next file’s work. That rejection propagates through `Promise.all` in the current batch, so `processBatches` stops and **`run()` fails**; later batches are not processed.
 - **Workflow-level:** `RunnerService.run()` wraps the body in `try`/`catch`, logs `Translation workflow failed`, then **rethrows** so `main` can exit with code `1`.
+
+### Empty discovery (no files to translate)
+
+When `FileDiscoveryManager.discoverFiles` returns zero files (for example every path already has a mergeable open PR, or language detection treats content as already translated), `fetchFilesToTranslate` logs at **info** and returns `false`. `RunnerService.run()` **does not** call `processInBatches`, then continues with `updateIssueWithResults` and `printFinalStatistics`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "translate-react",
-	"version": "0.1.26",
+	"version": "0.1.27",
 	"contributors": [
 		{
 			"name": "Nivaldo Farias",

--- a/src/errors/error.ts
+++ b/src/errors/error.ts
@@ -5,7 +5,6 @@ export enum ErrorCode {
 	// Domain Workflow Errors
 	TranslationFailed = "TRANSLATION_FAILED",
 	ChunkProcessingFailed = "CHUNK_PROCESSING_FAILED",
-	NoFilesToTranslate = "NO_FILES_TO_TRANSLATE",
 	NoContent = "NO_CONTENT",
 
 	// Domain Validation Errors

--- a/src/services/runner/base.service.ts
+++ b/src/services/runner/base.service.ts
@@ -2,6 +2,7 @@ import { sleep } from "bun";
 
 import type {
 	PatchedRepositoryTreeItem,
+	PrFilterResult,
 	ProcessedFileResult,
 	RepositoryTreeItem,
 	RunnerOptions,
@@ -225,6 +226,24 @@ export abstract class BaseRunnerService {
 	}
 
 	/**
+	 * Rebuilds {@link managers.translationBatch} with {@link resolveRunnerNewIssueChooserUrl} and
+	 * invalid-PR metadata, regardless of whether `filesToTranslate` came from discovery or a
+	 * pre-filled {@link state}.
+	 *
+	 * @param invalidPRsByFile Paths to open PRs that need conflict messaging in new PR bodies
+	 */
+	private rebuildTranslationBatchManager(invalidPRsByFile: PrFilterResult["invalidPRsByFile"]) {
+		const newIssueChooserUrl = resolveRunnerNewIssueChooserUrl();
+
+		this.managers.translationBatch = new TranslationBatchManager(
+			this.services,
+			invalidPRsByFile,
+			this.metadata.timestamp,
+			{ newIssueChooserUrl },
+		);
+	}
+
+	/**
 	 * Fetches and filters files that need translation through a multi-stage pipeline.
 	 *
 	 * Orchestrates the complete file discovery workflow using {@link FileDiscoveryManager}
@@ -242,14 +261,16 @@ export abstract class BaseRunnerService {
 	 * Files with existing PRs that have merge conflicts are identified and stored in
 	 * {@link state.invalidPRsByFile} for notification in new PR descriptions.
 	 *
-	 * @throws {ApplicationError} with {@link ErrorCode.NoFilesToTranslate} If no files are found to translate
+	 * @returns `true` when there is at least one file to translate; `false` when discovery
+	 * produced no candidates, in which case the caller should skip batch translation.
 	 */
-	protected async fetchFilesToTranslate(): Promise<void> {
+	protected async fetchFilesToTranslate() {
 		if (this.state.filesToTranslate.length) {
 			this.logger.info(
 				`Found ${this.state.filesToTranslate.length} files to translate (from cache)`,
 			);
-			return;
+			this.rebuildTranslationBatchManager(this.state.invalidPRsByFile ?? new Map());
+			return true;
 		}
 
 		const { filesToTranslate, invalidPRsByFile } = await this.managers.fileDiscovery.discoverFiles(
@@ -257,12 +278,11 @@ export abstract class BaseRunnerService {
 		);
 
 		if (filesToTranslate.length === 0) {
-			throw new ApplicationError(
-				"Found no files to translate",
-				ErrorCode.NoFilesToTranslate,
-				`${BaseRunnerService.name}.${this.fetchFilesToTranslate.name}`,
-				{ filesToTranslate, invalidPRsByFile },
+			this.logger.info(
+				{ invalidPRFileCount: invalidPRsByFile.size },
+				"No files to translate after discovery; skipping batch translation",
 			);
+			return false;
 		}
 
 		this.logger.info(
@@ -273,14 +293,9 @@ export abstract class BaseRunnerService {
 		this.state.filesToTranslate = filesToTranslate;
 		this.state.invalidPRsByFile = invalidPRsByFile;
 
-		const newIssueChooserUrl = resolveRunnerNewIssueChooserUrl();
+		this.rebuildTranslationBatchManager(invalidPRsByFile);
 
-		this.managers.translationBatch = new TranslationBatchManager(
-			this.services,
-			invalidPRsByFile,
-			this.metadata.timestamp,
-			{ newIssueChooserUrl },
-		);
+		return true;
 	}
 
 	/** Updates the progress issue with the translation results */

--- a/src/services/runner/runner.service.ts
+++ b/src/services/runner/runner.service.ts
@@ -56,8 +56,8 @@ export class RunnerService extends BaseRunnerService {
 	 * 2. Verifies GitHub token permissions
 	 * 3. Syncs fork with upstream
 	 * 4. Fetches repository tree
-	 * 5. Identifies files for translation
-	 * 6. Processes files in batches
+	 * 5. Identifies files for translation (when none remain after filtering, batch translation is skipped)
+	 * 6. Processes files in batches when there is work to do
 	 * 7. Reports results
 	 *
 	 * @returns Statistics about the workflow execution (success/failure counts)
@@ -70,8 +70,10 @@ export class RunnerService extends BaseRunnerService {
 
 			await this.fetchRepositoryTree();
 
-			await this.fetchFilesToTranslate();
-			await this.processInBatches();
+			const hasFilesToTranslate = await this.fetchFilesToTranslate();
+			if (hasFilesToTranslate) {
+				await this.processInBatches();
+			}
 
 			this.state.processedResults = Array.from(this.metadata.results.values());
 

--- a/tests/services/runner/runner.service.spec.ts
+++ b/tests/services/runner/runner.service.spec.ts
@@ -64,13 +64,18 @@ describe("RunnerService", () => {
 			expect(runner.run()).rejects.toThrow(ApplicationError);
 		});
 
-		test("throws ApplicationError with NoFilesToTranslate when repository tree is empty", () => {
+		test("completes successfully with empty statistics when repository tree yields no translation work", async () => {
 			const github = createMockGitHubService();
 			github.getRepositoryTree.mockResolvedValue([]);
 
 			const runner = createTestRunnerService({ github: github as unknown as GitHubService });
 
-			expect(runner.run()).rejects.toThrow("Found no files to translate");
+			const stats = await runner.run();
+
+			expect(stats.totalCount).toBe(0);
+			expect(stats.successCount).toBe(0);
+			expect(stats.failureCount).toBe(0);
+			expect(stats.successRate).toBe(0);
 		});
 
 		test("proceeds without error when fetchTranslationGuidelinesFile returns null", async () => {


### PR DESCRIPTION

- **Runner:** When translation discovery returns no files, the workflow no longer fails the run. `fetchFilesToTranslate` signals whether there is work; with nothing to do we skip `processInBatches`, log at info, and still refresh the batch manager and issue/update stats. `ErrorCode.NoFilesToTranslate` is removed; `docs/WORKFLOW.md` and `runner.service.spec.ts` describe and cover the path.
- **Release:** Bump `package.json` to `0.1.27` and add `CHANGELOG.md` for that version (including the missing `[0.1.26]` release link in the footer).
