### PR TITLE
feat(services): add pt-br fenced-code policy and validation guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ## [Unreleased]
 
+### Added
+
+- pt-br fenced-code policy: locale rules, prompt scope override, and `fencePreservedDemoContent` guard for demo UI strings and React terms in code comments.
+
 ### Fixed
 
 - `LocaleService` fails fast when a locale definition is missing instead of falling back to `pt-br`.

--- a/src/app/locales/pt-br.locale.ts
+++ b/src/app/locales/pt-br.locale.ts
@@ -90,7 +90,13 @@ export const ptBrLocale: LocaleDefinition = {
 - ALWAYS translate 'deprecated' and related terms (deprecation, deprecating, deprecates) to 'descontinuado(a)', 'descontinuada', 'obsoleto(a)' or 'obsoleta' in ALL contexts (documentation text, comments, headings, lists, etc.)
 	- Exception: Do NOT translate 'deprecated' in HTML comment IDs like {/*deprecated-something*/} - keep these exactly as-is
 	- Exception: Do NOT translate 'deprecated' in URLs, anchor links, or code variable names
-- When a MDN document is referenced, update the language slug to the Brazilian Portuguese version ('https://developer.mozilla.org/<slug>/*' => 'https://developer.mozilla.org/pt-BR/*')`,
+- When a MDN document is referenced, update the language slug to the Brazilian Portuguese version ('https://developer.mozilla.org/<slug>/*' => 'https://developer.mozilla.org/pt-BR/*')
+
+## FENCED CODE AND MDX (pt-br.react.dev)
+- Inside fenced code blocks: do NOT translate string literals or JSX text used as demo UI copy (labels like \`Created at:\`, button text, \`<h1>\` headings in examples). Copy them exactly from the source in English.
+- Keep React API vocabulary in \`//\` and \`/* */\` code comments in English (\`state\`, \`effect\`, \`ref\`, \`props\`, \`reducer\`, \`dispatch\`, \`context\`, \`memo\`, \`render\`, \`suspense\`, etc.) unless the translation guidelines explicitly map the term.
+- When you translate a code comment into Portuguese, translate the full comment. Do not mix English words into Portuguese sentences except for official API names from the list above.
+- \`<ConsoleLogLine>\` and similar MDX console output: keep message text in English to match runtime console output; do not localize error strings.`,
 	},
 	pullRequest: {
 		title: (file: TranslationFile) => `Tradução de \`${file.filename}\` para Português (Brasil)`,

--- a/src/app/services/translator/llm/translation-prompt.builder.ts
+++ b/src/app/services/translator/llm/translation-prompt.builder.ts
@@ -127,10 +127,7 @@ export class TranslationPromptBuilder {
 				4. **Whitespace Integrity**: ALWAYS preserve blank lines, especially after horizontal rules (---). The pattern '---\n\n##' must remain '---\n\n##' and never become '---\n##'
 	
 				# TRANSLATION GUIDELINES
-				## What to Translate
-				- Natural language text and documentation content
-				- Code comments and string literals (when they contain user-facing text)
-				- Alt text, titles, and descriptive content
+				${this.buildMarkdownTranslationScopeSection()}
 	
 				## What NOT to Translate
 				- API endpoints; URLs, paths, and configuration values; technical terms unless the translation guidelines map them
@@ -225,6 +222,36 @@ export class TranslationPromptBuilder {
 				A previous translation of this content was rejected. Apply every correction below in a new full translation of the user message:
 				${attemptContext.validationRetryHints.map((hint) => `- ${hint}`).join("\n")}
 				`;
+	}
+
+	/**
+	 * Builds the "What to Translate" scope for markdown body translation.
+	 *
+	 * pt-br uses stricter fenced-code rules aligned with pt-br.react.dev; other locales keep the default scope.
+	 *
+	 * @returns Markdown bullet sections for translation scope
+	 */
+	private buildMarkdownTranslationScopeSection() {
+		if (this.locale.languageCode === "pt-br") {
+			return `
+				## What to Translate
+				- Natural language text and documentation content outside fenced code blocks
+				- Alt text, titles, and descriptive content in prose
+	
+				## Fenced code blocks and MDX in examples
+				- Do NOT translate demo UI strings: quoted literals and JSX text between tags inside fenced code. Copy them exactly from the source.
+				- Keep programming identifiers unchanged in every fenced block.
+				- For \`//\` and \`/* */\` comments in fenced code, follow the locale-specific fenced-code rules below (React API terms stay in English; translate full comment text when translating).
+				- Keep \`<ConsoleLogLine>\` and similar MDX console message text in English to match runtime output.
+			`;
+		}
+
+		return `
+				## What to Translate
+				- Natural language text and documentation content
+				- Code comments and string literals (when they contain user-facing text)
+				- Alt text, titles, and descriptive content
+			`;
 	}
 
 	private getLogger() {

--- a/src/app/services/translator/validation/analyzers/fence-preserved-demo-content.analyzer.ts
+++ b/src/app/services/translator/validation/analyzers/fence-preserved-demo-content.analyzer.ts
@@ -1,0 +1,221 @@
+import { extractFencedCodeBlockBodies } from "./fence-code-identifier.analyzer";
+
+/** One demo string or JSX text node removed or altered inside a paired fence */
+export interface FencePreservedDemoContentMismatch {
+	/** 1-based fence index in document order */
+	fenceIndex: number;
+
+	/** Source snippet that should have been copied verbatim */
+	sourceSnippet: string;
+}
+
+/** React API terms that must stay in English inside `//` line comments in fenced code */
+const PROTECTED_REACT_COMMENT_TERMS = [
+	"state",
+	"effect",
+	"effects",
+	"ref",
+	"refs",
+	"props",
+	"reducer",
+	"dispatch",
+	"context",
+	"memo",
+	"callback",
+	"suspense",
+	"render",
+	"hydration",
+	"hook",
+	"hooks",
+] as const;
+
+const QUOTED_STRING_LITERAL = new RegExp(/(['"])(?:\\.|(?!\1).)*?\1/g);
+
+const JSX_TEXT_NODE = new RegExp(/>\s*([^<>{}]+?)\s*</g);
+
+const JSX_ATTRIBUTE_STRING = new RegExp(/=\s*(['"])([^'"\\]|\\.)*\1/g);
+
+const MDX_ELEMENT_TEXT = new RegExp(/<ConsoleLogLine[^>]*>\s*([^<]+?)\s*<\/ConsoleLogLine>/gi);
+
+const LINE_COMMENT = new RegExp(/\/\/[^\n]*/g);
+
+/**
+ * Detects demo UI strings and JSX text in fenced blocks that were translated instead of copied.
+ *
+ * @param sourceMarkdown Original markdown
+ * @param translatedMarkdown Translated markdown
+ *
+ * @returns Mismatches when a preserved snippet from the source fence is missing in the paired fence
+ */
+export function findFencePreservedDemoContentMismatches(
+	sourceMarkdown: string,
+	translatedMarkdown: string,
+) {
+	const sourceFences = extractFencedCodeBlockBodies(sourceMarkdown);
+	const translatedFences = extractFencedCodeBlockBodies(translatedMarkdown);
+
+	if (sourceFences.length !== translatedFences.length) {
+		return [];
+	}
+
+	const mismatches: FencePreservedDemoContentMismatch[] = [];
+
+	for (let index = 0; index < sourceFences.length; index++) {
+		const sourceFence = sourceFences[index];
+		const translatedFence = translatedFences[index];
+		if (!sourceFence || translatedFence === undefined) continue;
+
+		for (const snippet of collectPreservedDemoSnippets(sourceFence)) {
+			if (!translatedFence.includes(snippet)) {
+				mismatches.push({ fenceIndex: index + 1, sourceSnippet: snippet });
+			}
+		}
+	}
+
+	return mismatches;
+}
+
+/**
+ * Detects React API terms dropped from `//` comments inside fenced code.
+ *
+ * @param sourceMarkdown Original markdown
+ * @param translatedMarkdown Translated markdown
+ *
+ * @returns Mismatches when a protected term in a source line comment is absent from the translated fence
+ */
+export function findFenceReactCommentTermMismatches(
+	sourceMarkdown: string,
+	translatedMarkdown: string,
+) {
+	const sourceFences = extractFencedCodeBlockBodies(sourceMarkdown);
+	const translatedFences = extractFencedCodeBlockBodies(translatedMarkdown);
+
+	if (sourceFences.length !== translatedFences.length) {
+		return [];
+	}
+
+	const mismatches: FencePreservedDemoContentMismatch[] = [];
+
+	for (let index = 0; index < sourceFences.length; index++) {
+		const sourceFence = sourceFences[index];
+		const translatedFence = translatedFences[index];
+		if (!sourceFence || translatedFence === undefined) continue;
+
+		for (const comment of sourceFence.match(LINE_COMMENT) ?? []) {
+			for (const term of PROTECTED_REACT_COMMENT_TERMS) {
+				const termPattern = new RegExp(`\\b${term}\\b`);
+				if (!termPattern.test(comment)) continue;
+				if (termPattern.test(translatedFence)) continue;
+
+				mismatches.push({
+					fenceIndex: index + 1,
+					sourceSnippet: term,
+				});
+			}
+		}
+	}
+
+	return mismatches;
+}
+
+/**
+ * Collects string literals and JSX text nodes that should remain in English inside a fence.
+ *
+ * @param fenceInner Fenced block inner text
+ *
+ * @returns Unique snippets in first-seen order
+ */
+export function collectPreservedDemoSnippets(fenceInner: string) {
+	const snippets: string[] = [];
+	const seen = new Set<string>();
+
+	const addSnippet = (raw: string) => {
+		const value = raw.trim();
+		if (!value || seen.has(value) || !isPreservedDemoSnippet(value)) return;
+
+		seen.add(value);
+		snippets.push(value);
+	};
+
+	for (const match of fenceInner.matchAll(QUOTED_STRING_LITERAL)) {
+		const quote = match[1];
+		const literal = match[0];
+		if (!quote || !literal) continue;
+
+		addSnippet(literal.slice(1, -1).replace(/\\(.)/g, "$1"));
+	}
+
+	for (const match of fenceInner.matchAll(JSX_ATTRIBUTE_STRING)) {
+		const literal = match[0];
+		const quote = match[1];
+		if (!quote || !literal) continue;
+
+		addSnippet(literal.slice(literal.indexOf(quote) + 1, -1).replace(/\\(.)/g, "$1"));
+	}
+
+	for (const match of fenceInner.matchAll(JSX_TEXT_NODE)) {
+		addSnippet(match[1] ?? "");
+	}
+
+	for (const match of fenceInner.matchAll(MDX_ELEMENT_TEXT)) {
+		addSnippet(match[1] ?? "");
+	}
+
+	return snippets;
+}
+
+/**
+ * Returns whether a fence snippet looks like demo UI copy that must stay in English for pt-br.
+ *
+ * @param value Unquoted string or JSX text
+ *
+ * @returns `true` when the snippet should be preserved verbatim
+ */
+export function isPreservedDemoSnippet(value: string) {
+	const trimmed = value.trim();
+	if (trimmed.length < 3 || !/[A-Za-z]/.test(trimmed)) return false;
+
+	if (/^[@./]|https?:\/\//i.test(trimmed)) return false;
+	if (/^[A-Za-z_$][\w$]*$/.test(trimmed)) return false;
+	if (/^(true|false|null|undefined|use[A-Z]\w*)$/i.test(trimmed)) return false;
+
+	if (trimmed.includes(" ") || trimmed.endsWith(":")) return true;
+	if (/[A-Z][a-z]+.*[A-Z]/.test(trimmed)) return true;
+
+	return trimmed.length >= 10 && /[a-z]/.test(trimmed) && /[A-Z]/.test(trimmed);
+}
+
+/**
+ * Builds a retry hint for preserved demo content inside fences.
+ *
+ * @param demoMismatches Demo string or JSX text mismatches
+ * @param commentTermMismatches React API terms missing from translated comments
+ *
+ * @returns Hint string for the LLM system prompt
+ */
+export function buildFencePreservedContentRetryHint(
+	demoMismatches: FencePreservedDemoContentMismatch[],
+	commentTermMismatches: FencePreservedDemoContentMismatch[],
+) {
+	const parts: string[] = [
+		"In fenced code blocks, keep demo UI strings and JSX text exactly as in the source (English).",
+	];
+
+	if (demoMismatches.length > 0) {
+		const examples = demoMismatches
+			.slice(0, 4)
+			.map(({ sourceSnippet }) => `copy \`${sourceSnippet}\` verbatim`)
+			.join("; ");
+		parts.push(examples);
+	}
+
+	if (commentTermMismatches.length > 0) {
+		const terms = [...new Set(commentTermMismatches.map(({ sourceSnippet }) => sourceSnippet))]
+			.slice(0, 6)
+			.map((term) => `\`${term}\``)
+			.join(", ");
+		parts.push(`Keep React API terms in \`//\` comments in English: ${terms}.`);
+	}
+
+	return parts.join(" ");
+}

--- a/src/app/services/translator/validation/guards/fence-preserved-demo-content.guard.ts
+++ b/src/app/services/translator/validation/guards/fence-preserved-demo-content.guard.ts
@@ -1,0 +1,40 @@
+import type { PostTranslationValidationGuard } from "../validation.types";
+
+import { env } from "@/app/utils/";
+
+import {
+	buildFencePreservedContentRetryHint,
+	findFencePreservedDemoContentMismatches,
+	findFenceReactCommentTermMismatches,
+} from "../analyzers/fence-preserved-demo-content.analyzer";
+
+/**
+ * Rejects pt-br translations that altered demo UI strings or React terms inside fenced code.
+ *
+ * @param source Original markdown before translation
+ * @param translated Model output to validate
+ *
+ * @returns Guard failure with retry hint, or `null` when fence demo content matches
+ */
+export const fencePreservedDemoContentGuard: PostTranslationValidationGuard = (
+	source,
+	translated,
+) => {
+	if (env.TARGET_LANGUAGE !== "pt-br") return null;
+
+	const demoMismatches = findFencePreservedDemoContentMismatches(source, translated);
+	const commentTermMismatches = findFenceReactCommentTermMismatches(source, translated);
+
+	if (demoMismatches.length === 0 && commentTermMismatches.length === 0) return null;
+
+	const snippets = [...demoMismatches, ...commentTermMismatches]
+		.map(({ sourceSnippet }) => sourceSnippet)
+		.slice(0, 6)
+		.join(", ");
+
+	return {
+		guardId: "fencePreservedDemoContent",
+		message: `Fenced demo content or React comment terms changed: ${snippets}`,
+		retryHint: buildFencePreservedContentRetryHint(demoMismatches, commentTermMismatches),
+	};
+};

--- a/src/app/services/translator/validation/guards/index.ts
+++ b/src/app/services/translator/validation/guards/index.ts
@@ -1,7 +1,10 @@
 import type { TranslationValidationIssue } from "../validation.types";
 
+import { env } from "@/app/utils/";
+
 import { contentRatioGuard } from "./content-ratio.guard";
 import { fenceFunctionIdentifiersGuard } from "./fence-function-identifiers.guard";
+import { fencePreservedDemoContentGuard } from "./fence-preserved-demo-content.guard";
 import { frontmatterPreservedGuard } from "./frontmatter-preserved.guard";
 import { headingsPreservedGuard } from "./headings-preserved.guard";
 import { nonEmptyContentGuard } from "./non-empty-content.guard";
@@ -13,6 +16,7 @@ export const POST_TRANSLATION_VALIDATION_GUARDS = [
 	headingsPreservedGuard,
 	frontmatterPreservedGuard,
 	fenceFunctionIdentifiersGuard,
+	...(env.TARGET_LANGUAGE === "pt-br" ? [fencePreservedDemoContentGuard] : []),
 ] as const;
 
 /**

--- a/tests/services/locale/locale.service.spec.ts
+++ b/tests/services/locale/locale.service.spec.ts
@@ -139,6 +139,11 @@ describe("LocaleService", () => {
 				expect(localeService.definitions.rules.specific).toContain("developer.mozilla.org");
 				expect(localeService.definitions.rules.specific).toContain("pt-BR");
 			});
+
+			test("should include fenced code and MDX rules for pt-br", () => {
+				expect(localeService.definitions.rules.specific).toContain("FENCED CODE AND MDX");
+				expect(localeService.definitions.rules.specific).toContain("ConsoleLogLine");
+			});
 		});
 	});
 });

--- a/tests/services/translator/validation/analyzers/fence-preserved-demo-content.analyzer.spec.ts
+++ b/tests/services/translator/validation/analyzers/fence-preserved-demo-content.analyzer.spec.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	collectPreservedDemoSnippets,
+	findFencePreservedDemoContentMismatches,
+	findFenceReactCommentTermMismatches,
+	isPreservedDemoSnippet,
+} from "@/app/services/translator/validation/analyzers/fence-preserved-demo-content.analyzer";
+
+describe("fence-preserved-demo-content.analyzer", () => {
+	test("isPreservedDemoSnippet accepts UI labels and rejects identifiers", () => {
+		expect(isPreservedDemoSnippet("Created at:")).toBe(true);
+		expect(isPreservedDemoSnippet("Create React App is Deprecated")).toBe(true);
+		expect(isPreservedDemoSnippet("useState")).toBe(false);
+		expect(isPreservedDemoSnippet("ProductCard")).toBe(false);
+	});
+
+	test("collectPreservedDemoSnippets gathers quoted literals and JSX text", () => {
+		const fence = `
+return (
+  <div>
+    <h1>Create React App is Deprecated</h1>
+    <p>Created at: {createdAt}</p>
+  </div>
+);
+`;
+
+		const snippets = collectPreservedDemoSnippets(fence);
+
+		expect(snippets).toContain("Create React App is Deprecated");
+	});
+
+	test("findFencePreservedDemoContentMismatches detects translated JSX heading (pt-br #1186)", () => {
+		const source = `
+\`\`\`jsx
+<h1>Create React App is Deprecated</h1>
+\`\`\`
+`;
+
+		const translated = `
+\`\`\`jsx
+<h1>O Create React App foi descontinuado</h1>
+\`\`\`
+`;
+
+		const mismatches = findFencePreservedDemoContentMismatches(source, translated);
+
+		expect(mismatches.length).toBeGreaterThan(0);
+		expect(mismatches[0]?.sourceSnippet).toBe("Create React App is Deprecated");
+	});
+
+	test("findFencePreservedDemoContentMismatches detects translated UI string (pt-br #1215)", () => {
+		const source = `
+\`\`\`js
+function Row({ createdAt }) {
+  return <label aria-label="Created at:">Created at: {createdAt}</label>;
+}
+\`\`\`
+`;
+
+		const translated = `
+\`\`\`js
+function Row({ createdAt }) {
+  return <label aria-label="Criado em:">Criado em: {createdAt}</label>;
+}
+\`\`\`
+`;
+
+		const mismatches = findFencePreservedDemoContentMismatches(source, translated);
+
+		expect(
+			mismatches.some(
+				(mismatch) => mismatch.fenceIndex === 1 && mismatch.sourceSnippet === "Created at:",
+			),
+		).toBe(true);
+	});
+
+	test("findFencePreservedDemoContentMismatches passes when demo strings are preserved", () => {
+		const source = `
+\`\`\`js
+<button>Submit form</button>
+\`\`\`
+`;
+
+		const translated = `
+\`\`\`js
+<button>Submit form</button>
+\`\`\`
+`;
+
+		expect(findFencePreservedDemoContentMismatches(source, translated)).toEqual([]);
+	});
+
+	test("findFenceReactCommentTermMismatches detects translated state in comment (pt-br #1218)", () => {
+		const source = `
+\`\`\`js
+// You can read state from a ref during render
+const ref = useRef(null);
+\`\`\`
+`;
+
+		const translated = `
+\`\`\`js
+// Você pode ler o estado de uma ref durante a renderização
+const ref = useRef(null);
+\`\`\`
+`;
+
+		const mismatches = findFenceReactCommentTermMismatches(source, translated);
+
+		expect(
+			mismatches.some(
+				(mismatch) => mismatch.fenceIndex === 1 && mismatch.sourceSnippet === "state",
+			),
+		).toBe(true);
+	});
+});

--- a/tests/services/translator/validation/guards/fence-preserved-demo-content.guard.spec.ts
+++ b/tests/services/translator/validation/guards/fence-preserved-demo-content.guard.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+
+import { fencePreservedDemoContentGuard } from "@/app/services/translator/validation/guards/fence-preserved-demo-content.guard";
+
+describe("fencePreservedDemoContentGuard", () => {
+	test("returns retryable issue when JSX demo text was translated", () => {
+		const source = `
+\`\`\`jsx
+<h1>Create React App is Deprecated</h1>
+\`\`\`
+`;
+
+		const translated = `
+\`\`\`jsx
+<h1>O Create React App foi descontinuado</h1>
+\`\`\`
+`;
+
+		const issue = fencePreservedDemoContentGuard(source, translated);
+
+		expect(issue).not.toBeNull();
+		expect(issue?.guardId).toBe("fencePreservedDemoContent");
+		expect(issue?.retryHint).toContain("demo UI strings");
+	});
+});


### PR DESCRIPTION
- Extend `pt-br.locale.ts` with fence, JSX, and `ConsoleLogLine` rules
- Narrow pt-br markdown prompt scope so demo strings stay in English
- Add `fencePreservedDemoContentGuard` for UI copy and React comment terms