### PR TITLE
feat(services): add maintainer feedback workflow for translation PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Added
 
+- Maintainer feedback workflow: detect member review after the latest runner commit, apply mechanical `diff`/suggestion patches or section-scoped re-translation with comment hints, then fall back to full re-translation; reuse branch and PR instead of reset.
 - pt-br fenced-code policy: locale rules, prompt scope override, and `fencePreservedDemoContent` guard for demo UI strings and React terms in code comments.
 
 ### Fixed

--- a/src/app/constants/index.ts
+++ b/src/app/constants/index.ts
@@ -1,4 +1,5 @@
 export * from "./error-messages.constants";
+export * from "./maintainer-feedback.constants";
 export * from "./environment.constants";
 export * from "./rate-limit.constants";
 export * from "./react-translation.constants";

--- a/src/app/constants/maintainer-feedback.constants.ts
+++ b/src/app/constants/maintainer-feedback.constants.ts
@@ -1,0 +1,12 @@
+/** Prefix of runner translation commits on fork `translate/…` branches */
+export const TRANSLATION_COMMIT_MESSAGE_PREFIX = "docs: translate ";
+
+/**
+ * GitHub `author_association` values treated as maintainer feedback on translation PRs.
+ *
+ * @see {@link https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#about-issue-comments|Issue comments}
+ */
+export const MAINTAINER_COMMENT_ASSOCIATIONS = new Set(["COLLABORATOR", "MEMBER", "OWNER"]);
+
+/** Bot logins excluded from maintainer-feedback detection */
+export const IGNORED_MAINTAINER_FEEDBACK_LOGINS = new Set(["github-actions[bot]", "vercel[bot]"]);

--- a/src/app/services/github/github.content.ts
+++ b/src/app/services/github/github.content.ts
@@ -9,6 +9,7 @@ import type { CommentBuilderService } from "@/app/services/comment-builder/";
 import type {
 	PatchedRepositoryTreeItem,
 	ProcessedFileResult,
+	PullRequestIssueCommentSnapshot,
 	PullRequestStatus,
 	RepositoryMarkdownBlob,
 	TranslationProgressFileRef,
@@ -16,6 +17,7 @@ import type {
 
 import type { SharedGitHubDependencies } from "./types";
 
+import { TRANSLATION_COMMIT_MESSAGE_PREFIX } from "@/app/constants/maintainer-feedback.constants";
 import { selectProgressCommentPayload } from "@/app/services/comment-builder/progress-comment.util";
 import { logger } from "@/app/utils/";
 import { ApplicationError, ErrorCode } from "@/shared/errors/";
@@ -639,6 +641,59 @@ export class GitHubContent {
 		});
 
 		return response.data;
+	}
+
+	/**
+	 * Lists issue comments on an open translation pull request (upstream repo).
+	 *
+	 * @param prNumber Pull request number on the upstream repository
+	 *
+	 * @returns Normalized issue comments, oldest first
+	 */
+	public async listPullRequestIssueComments(
+		prNumber: number,
+	): Promise<PullRequestIssueCommentSnapshot[]> {
+		const comments = await this.deps.octokit.paginate(this.deps.octokit.issues.listComments, {
+			...this.deps.repositories.upstream,
+			issue_number: prNumber,
+			per_page: 100,
+		});
+
+		return comments.map((comment) => ({
+			login: comment.user?.login ?? "",
+			authorAssociation: comment.author_association,
+			userType: comment.user?.type ?? "User",
+			createdAt: new Date(comment.created_at),
+			body: comment.body ?? "",
+		}));
+	}
+
+	/**
+	 * Returns the committer timestamp of the latest runner translation commit on a fork branch.
+	 *
+	 * @param branchName Translation branch name without `refs/heads/` prefix
+	 *
+	 * @returns Committer date of the newest `docs: translate` commit, or `undefined` when none exist
+	 */
+	public async getLatestTranslationCommitTimestamp(branchName: string): Promise<Date | undefined> {
+		const response = await this.deps.octokit.repos.listCommits({
+			...this.deps.repositories.fork,
+			sha: branchName,
+			per_page: 30,
+		});
+
+		const translationCommit = response.data.find((commit) =>
+			commit.commit.message.startsWith(TRANSLATION_COMMIT_MESSAGE_PREFIX),
+		);
+
+		if (!translationCommit) {
+			return undefined;
+		}
+
+		const timestamp =
+			translationCommit.commit.committer?.date ?? translationCommit.commit.author?.date;
+
+		return timestamp ? new Date(timestamp) : undefined;
 	}
 
 	/**

--- a/src/app/services/github/github.service.ts
+++ b/src/app/services/github/github.service.ts
@@ -330,6 +330,28 @@ export class GitHubService {
 	}
 
 	/**
+	 * Lists issue comments on a translation pull request.
+	 *
+	 * @param prNumber Pull request number on the upstream repository
+	 *
+	 * @returns Normalized issue comments for maintainer-feedback detection
+	 */
+	public async listPullRequestIssueComments(prNumber: number) {
+		return this.content.listPullRequestIssueComments(prNumber);
+	}
+
+	/**
+	 * Returns the timestamp of the latest runner translation commit on a fork branch.
+	 *
+	 * @param branchName Translation branch name without `refs/heads/` prefix
+	 *
+	 * @returns Committer date of the newest translation commit, if present
+	 */
+	public async getLatestTranslationCommitTimestamp(branchName: string) {
+		return this.content.getLatestTranslationCommitTimestamp(branchName);
+	}
+
+	/**
 	 * Posts translation results as comments on GitHub issues.
 	 *
 	 * @param results Translation results to report

--- a/src/app/services/github/types.ts
+++ b/src/app/services/github/types.ts
@@ -110,6 +110,24 @@ export interface PatchedRepositoryTreeItem extends SetRequired<RepositoryTreeIte
 	filename: string;
 }
 
+/** Normalized pull request issue comment for maintainer-feedback detection */
+export interface PullRequestIssueCommentSnapshot {
+	/** GitHub login of the comment author */
+	readonly login: string;
+
+	/** GitHub `author_association` for the comment */
+	readonly authorAssociation: string;
+
+	/** GitHub user `type` (`User`, `Bot`, etc.) */
+	readonly userType: string;
+
+	/** When the comment was created */
+	readonly createdAt: Date;
+
+	/** Issue comment body markdown */
+	readonly body: string;
+}
+
 /** Pull request mergeability and conflict status */
 export interface PullRequestStatus {
 	/** Whether the PR has actual merge conflicts (dirty state) */

--- a/src/app/services/runner/workflow/maintainer-feedback-remediation.manager.ts
+++ b/src/app/services/runner/workflow/maintainer-feedback-remediation.manager.ts
@@ -1,0 +1,171 @@
+import type {
+	TranslationResult,
+	TranslatorService,
+} from "@/app/services/translator/translator.service";
+
+import { TranslationFile } from "@/app/services/translator/";
+
+import {
+	applyMechanicalLineReplacements,
+	parseMechanicalLineReplacements,
+} from "./maintainer-mechanical-fix.util";
+import {
+	extractFirstHeadingSlug,
+	extractMarkdownSectionBySlug,
+	replaceMarkdownSectionBySlug,
+} from "./markdown-section.util";
+
+/** How maintainer feedback was applied to the translated file */
+export type MaintainerRemediationKind = "mechanical" | "section";
+
+/** Successful targeted remediation without a full-document re-translation */
+export interface MaintainerRemediationResult {
+	/** Remediation tier that produced the content */
+	readonly kind: MaintainerRemediationKind;
+
+	/** Updated translated markdown for the fork branch */
+	readonly content: string;
+
+	/** Validation retries from section-scoped LLM, if any */
+	readonly retries: TranslationResult["retries"];
+}
+
+/**
+ * Applies maintainer feedback tiers (mechanical, then section-scoped LLM) before full re-translation.
+ */
+export class MaintainerFeedbackRemediationManager {
+	/**
+	 * @param translator Translator used for section-scoped re-translation
+	 */
+	constructor(private readonly translator: TranslatorService) {}
+
+	/**
+	 * Tries mechanical patches, then section-scoped translation using maintainer comments.
+	 *
+	 * @param forkContent Current translated markdown on the fork branch
+	 * @param sourceContent English upstream markdown for section-scoped translation
+	 * @param commentBodies Maintainer issue comment bodies after the latest runner commit
+	 * @param file Translation file metadata for logging and LLM context
+	 *
+	 * @returns Remediation outcome, or `undefined` to fall back to full re-translation
+	 */
+	public async tryRemediate(
+		forkContent: string,
+		sourceContent: string,
+		commentBodies: readonly string[],
+		file: TranslationFile,
+	): Promise<MaintainerRemediationResult | undefined> {
+		const mechanical = this.tryMechanicalRemediation(forkContent, commentBodies);
+
+		if (mechanical) {
+			return mechanical;
+		}
+
+		return this.trySectionRemediation({ forkContent, sourceContent, commentBodies, file });
+	}
+
+	/**
+	 * Tries mechanical patches for line-level replacements in maintainer comments.
+	 *
+	 * @param forkContent Current translated markdown on the fork branch
+	 * @param commentBodies Maintainer issue comment bodies after the latest runner commit
+	 *
+	 * @returns Remediation outcome, or `undefined` when no replacements were applied
+	 */
+	private tryMechanicalRemediation(
+		forkContent: string,
+		commentBodies: readonly string[],
+	): MaintainerRemediationResult | undefined {
+		const replacements = parseMechanicalLineReplacements(commentBodies);
+		const { content, appliedCount } = applyMechanicalLineReplacements(forkContent, replacements);
+
+		if (appliedCount === 0) {
+			return undefined;
+		}
+
+		return { kind: "mechanical", content, retries: [] };
+	}
+
+	/**
+	 * Tries section-scoped translation using maintainer comments.
+	 *
+	 * @param params Current translated markdown on the fork branch
+	 * @param params.forkContent Current translated markdown on the fork branch
+	 * @param params.sourceContent English upstream markdown for section-scoped translation
+	 * @param params.commentBodies Maintainer issue comment bodies after the latest runner commit
+	 * @param params.file Translation file metadata for logging and LLM context
+	 *
+	 * @returns Remediation outcome, or `undefined` when no section was found
+	 */
+	private async trySectionRemediation({
+		forkContent,
+		sourceContent,
+		commentBodies,
+		file,
+	}: {
+		forkContent: string;
+		sourceContent: string;
+		commentBodies: readonly string[];
+		file: TranslationFile;
+	}): Promise<MaintainerRemediationResult | undefined> {
+		const slug = this.resolveSectionSlug(commentBodies, forkContent);
+
+		if (!slug) {
+			return undefined;
+		}
+
+		const sourceSection = extractMarkdownSectionBySlug(sourceContent, slug);
+		const forkSection = extractMarkdownSectionBySlug(forkContent, slug);
+
+		if (!sourceSection || !forkSection) {
+			return undefined;
+		}
+
+		const hints = commentBodies.map(
+			(body) => `Maintainer review feedback for this section:\n${body.trim()}`,
+		);
+
+		const sectionFile = new TranslationFile(
+			sourceSection.section,
+			file.filename,
+			file.path,
+			file.sha,
+			file.logger,
+		);
+
+		const translated = await this.translator.translateContent(sectionFile, {
+			validationRetryHints: hints,
+		});
+
+		const merged = replaceMarkdownSectionBySlug(forkContent, slug, translated.content);
+
+		if (!merged) {
+			return undefined;
+		}
+
+		return { kind: "section", content: merged, retries: translated.retries };
+	}
+
+	/**
+	 * Resolves the slug comment value from the first maintainer comment body that contains a heading.
+	 *
+	 * @param commentBodies Maintainer issue comment bodies after the latest runner commit
+	 * @param forkContent Current translated markdown on the fork branch
+	 *
+	 * @returns Slug string, or `undefined` when no heading was found
+	 */
+	private resolveSectionSlug(
+		commentBodies: readonly string[],
+		forkContent: string,
+	): string | undefined {
+		for (const body of commentBodies) {
+			const slug = extractFirstHeadingSlug(body);
+
+			if (slug && extractMarkdownSectionBySlug(forkContent, slug)) {
+				return slug;
+			}
+		}
+
+		return undefined;
+	}
+}

--- a/src/app/services/runner/workflow/maintainer-feedback.util.ts
+++ b/src/app/services/runner/workflow/maintainer-feedback.util.ts
@@ -1,0 +1,69 @@
+import type { PullRequestIssueCommentSnapshot } from "@/app/services/github/types";
+
+import {
+	IGNORED_MAINTAINER_FEEDBACK_LOGINS,
+	MAINTAINER_COMMENT_ASSOCIATIONS,
+} from "@/app/constants/maintainer-feedback.constants";
+
+/**
+ * Whether a pull request comment counts as maintainer review feedback.
+ *
+ * @param comment Normalized issue comment on the translation pull request
+ *
+ * @returns `true` for repository members and collaborators, excluding known bots
+ */
+export function isMaintainerFeedbackComment(comment: PullRequestIssueCommentSnapshot): boolean {
+	if (comment.userType === "Bot") {
+		return false;
+	}
+
+	if (IGNORED_MAINTAINER_FEEDBACK_LOGINS.has(comment.login)) {
+		return false;
+	}
+
+	return MAINTAINER_COMMENT_ASSOCIATIONS.has(comment.authorAssociation);
+}
+
+/**
+ * Whether maintainer feedback exists after the latest runner commit on the branch.
+ *
+ * @param comments Issue comments on the translation pull request
+ * @param runnerCommitAt Timestamp of the latest `docs: translate` commit, if any
+ *
+ * @returns `true` when a maintainer comment was posted after that commit
+ */
+export function hasMaintainerFeedbackAfterRunnerCommit(
+	comments: readonly PullRequestIssueCommentSnapshot[],
+	runnerCommitAt: Date | undefined,
+): boolean {
+	if (!runnerCommitAt) {
+		return false;
+	}
+
+	return comments.some(
+		(comment) => isMaintainerFeedbackComment(comment) && comment.createdAt > runnerCommitAt,
+	);
+}
+
+/**
+ * Returns maintainer comment bodies posted after the latest runner commit, oldest first.
+ *
+ * @param comments Issue comments on the translation pull request
+ * @param runnerCommitAt Timestamp of the latest `docs: translate` commit on the branch
+ *
+ * @returns Markdown bodies to parse for mechanical or section remediation
+ */
+export function getMaintainerFeedbackCommentBodies(
+	comments: readonly PullRequestIssueCommentSnapshot[],
+	runnerCommitAt: Date | undefined,
+): string[] {
+	if (!runnerCommitAt) {
+		return [];
+	}
+
+	return comments
+		.filter((comment) => isMaintainerFeedbackComment(comment) && comment.createdAt > runnerCommitAt)
+		.sort((left, right) => left.createdAt.getTime() - right.createdAt.getTime())
+		.map((comment) => comment.body)
+		.filter((body) => body.trim().length > 0);
+}

--- a/src/app/services/runner/workflow/maintainer-mechanical-fix.util.ts
+++ b/src/app/services/runner/workflow/maintainer-mechanical-fix.util.ts
@@ -1,0 +1,135 @@
+/** One line-level search-and-replace pair from a maintainer `diff` block or suggestion */
+export interface MechanicalLineReplacement {
+	/** Exact substring to remove from the translated file */
+	readonly search: string;
+
+	/** Replacement text */
+	readonly replace: string;
+}
+
+/**
+ * Parses unified-diff hunks and suggestion blocks from maintainer comment bodies.
+ *
+ * @param commentBodies Maintainer issue comment markdown bodies
+ *
+ * @returns De-duplicated line replacements in comment order
+ */
+export function parseMechanicalLineReplacements(
+	commentBodies: readonly string[],
+): MechanicalLineReplacement[] {
+	const replacements: MechanicalLineReplacement[] = [];
+	const seen = new Set<string>();
+
+	for (const body of commentBodies) {
+		for (const replacement of [
+			...parseDiffBlockReplacements(body),
+			...parseSuggestionBlockReplacements(body),
+		]) {
+			const key = `${replacement.search}\0${replacement.replace}`;
+
+			if (seen.has(key)) {
+				continue;
+			}
+
+			seen.add(key);
+			replacements.push(replacement);
+		}
+	}
+
+	return replacements;
+}
+
+/**
+ * Applies line replacements to translated content when each `search` occurs exactly once.
+ *
+ * @param content Current translated markdown on the fork branch
+ * @param replacements Parsed mechanical replacements
+ *
+ * @returns Updated content and how many replacements were applied
+ */
+export function applyMechanicalLineReplacements(
+	content: string,
+	replacements: readonly MechanicalLineReplacement[],
+): { content: string; appliedCount: number } {
+	let updated = content;
+	let appliedCount = 0;
+
+	for (const { search, replace } of replacements) {
+		if (!search.length || search === replace || !updated.includes(search)) {
+			continue;
+		}
+
+		const firstIndex = updated.indexOf(search);
+
+		if (updated.includes(search, firstIndex + 1)) {
+			continue;
+		}
+
+		updated = `${updated.slice(0, firstIndex)}${replace}${updated.slice(firstIndex + search.length)}`;
+		appliedCount++;
+	}
+
+	return { content: updated, appliedCount };
+}
+
+/**
+ * Parses diff-fenced blocks in maintainer comments into line replacements.
+ *
+ * @param body Maintainer comment markdown
+ *
+ * @returns Line replacements extracted from diff fences
+ */
+function parseDiffBlockReplacements(body: string): MechanicalLineReplacement[] {
+	const replacements: MechanicalLineReplacement[] = [];
+	const diffBlockPattern = /```diff\n([\s\S]*?)```/g;
+
+	for (const match of body.matchAll(diffBlockPattern)) {
+		const block = match[1] ?? "";
+		const lines = block.split("\n");
+
+		for (let index = 0; index < lines.length; index++) {
+			const line = lines[index] ?? "";
+
+			if (!line.startsWith("-") || line.startsWith("---")) {
+				continue;
+			}
+
+			const nextLine = lines[index + 1] ?? "";
+
+			if (!nextLine.startsWith("+")) {
+				continue;
+			}
+
+			replacements.push({
+				search: line.slice(1),
+				replace: nextLine.slice(1),
+			});
+			index++;
+		}
+	}
+
+	return replacements;
+}
+
+/**
+ * Parses maintainer before/after code blocks into one block replacement.
+ *
+ * @param body Maintainer comment markdown
+ *
+ * @returns A single block replacement when both excerpts are present
+ */
+function parseSuggestionBlockReplacements(body: string): MechanicalLineReplacement[] {
+	const buggyMatch = /\*\*Traduzido[^*]*\*\*:?\s*```[^\n]*\n([\s\S]*?)```/.exec(body);
+	const fixMatch = /Sugestão de correção:\s*```[^\n]*\n([\s\S]*?)```/.exec(body);
+
+	if (!buggyMatch?.[1] || !fixMatch?.[1]) {
+		return [];
+	}
+
+	return [
+		{
+			search: buggyMatch[1].trim(),
+			replace: fixMatch[1].trim(),
+		},
+	];
+}

--- a/src/app/services/runner/workflow/markdown-section.util.ts
+++ b/src/app/services/runner/workflow/markdown-section.util.ts
@@ -1,0 +1,102 @@
+/** A contiguous markdown section bounded by one heading and the next peer-or-higher heading */
+export interface MarkdownSectionSlice {
+	/** Document content before the section heading line */
+	readonly prefix: string;
+
+	/** Section from the heading line through the line before the next boundary */
+	readonly section: string;
+
+	/** Document content after the section */
+	readonly suffix: string;
+}
+
+/**
+ * Extracts a markdown section whose heading line contains slug comment.
+ *
+ * @param content Full markdown document
+ * @param slug JSX slug comment value without braces (e.g. `opting-out-of-an-animation`)
+ *
+ * @returns Section slice, or `undefined` when the slug heading is not found
+ */
+export function extractMarkdownSectionBySlug(
+	content: string,
+	slug: string,
+): MarkdownSectionSlice | undefined {
+	const headingPattern = new RegExp(
+		`^(#{1,6}\\s.+\\{\\/\\*${escapeRegExp(slug)}\\*\\/\\})\\s*$`,
+		"m",
+	);
+	const headingMatch = headingPattern.exec(content);
+
+	if (headingMatch?.index === undefined) {
+		return undefined;
+	}
+
+	const headingLine = headingMatch[1];
+
+	if (!headingLine) {
+		return undefined;
+	}
+
+	const headingLevelMatch = /^(#+)/.exec(headingLine);
+	const headingLevel = headingLevelMatch?.[1]?.length ?? 1;
+	const sectionStart = headingMatch.index;
+	const bodyStart = sectionStart + headingMatch[0].length;
+	const boundaryPattern = new RegExp(`^#{1,${headingLevel}}\\s`, "m");
+	const rest = content.slice(bodyStart);
+	const boundaryMatch = boundaryPattern.exec(rest);
+	const sectionEnd = boundaryMatch ? bodyStart + boundaryMatch.index : content.length;
+
+	return {
+		prefix: content.slice(0, sectionStart),
+		section: content.slice(sectionStart, sectionEnd),
+		suffix: content.slice(sectionEnd),
+	};
+}
+
+/**
+ * Replaces a markdown section identified by slug comment on its heading line.
+ *
+ * @param content Full markdown document
+ * @param slug JSX slug comment value without braces
+ * @param newSection Replacement section including its heading line
+ *
+ * @returns Updated document, or `undefined` when the slug heading is not found
+ */
+export function replaceMarkdownSectionBySlug(
+	content: string,
+	slug: string,
+	newSection: string,
+): string | undefined {
+	const slice = extractMarkdownSectionBySlug(content, slug);
+
+	if (!slice) {
+		return undefined;
+	}
+
+	const normalizedSection = newSection.endsWith("\n") ? newSection : `${newSection}\n`;
+
+	return `${slice.prefix}${normalizedSection}${slice.suffix}`;
+}
+
+/**
+ * Returns the first slug comment value from text when present.
+ *
+ * @param text Maintainer comment or heading line
+ *
+ * @returns Slug string, or `undefined` when no slug comment is present
+ */
+export function extractFirstHeadingSlug(text: string): string | undefined {
+	return /\{\/\*([^*]+)\*\/\}/.exec(text)?.[1];
+}
+
+/**
+ * Escapes a string for safe use inside a `RegExp`.
+ *
+ * @param value Raw slug or path fragment
+ *
+ * @returns Escaped string for interpolation into a regex pattern
+ */
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/app/services/runner/workflow/translation-batch.manager.ts
+++ b/src/app/services/runner/workflow/translation-batch.manager.ts
@@ -7,6 +7,8 @@ import type { FileProcessingProgress } from "@/app/services/runner/types";
 
 import type { RunnerServiceDependencies } from "../runner.types";
 
+import type { TranslationPullRequestValidity } from "./translation-pull-request-validity.manager";
+
 import { PullRequestProgressAction } from "@/app/services/github/types";
 import { TranslationFile } from "@/app/services/translator/";
 import {
@@ -17,6 +19,8 @@ import {
 } from "@/app/utils/";
 import { ApplicationError, ErrorCode } from "@/shared/errors/";
 
+import { MaintainerFeedbackRemediationManager } from "./maintainer-feedback-remediation.manager";
+import { getMaintainerFeedbackCommentBodies } from "./maintainer-feedback.util";
 import { TranslationPullRequestValidityManager } from "./translation-pull-request-validity.manager";
 import { MAX_CONSECUTIVE_FAILURES } from "./workflow.constants";
 
@@ -67,6 +71,8 @@ export class TranslationBatchManager {
 
 	private readonly translationPullRequestValidity: TranslationPullRequestValidityManager;
 
+	private readonly maintainerFeedbackRemediation: MaintainerFeedbackRemediationManager;
+
 	/**
 	 * Initializes the batch manager with service dependencies.
 	 *
@@ -80,6 +86,9 @@ export class TranslationBatchManager {
 		private readonly workflowStartTimestamp: number,
 	) {
 		this.translationPullRequestValidity = new TranslationPullRequestValidityManager(services);
+		this.maintainerFeedbackRemediation = new MaintainerFeedbackRemediationManager(
+			services.translator,
+		);
 	}
 
 	/**
@@ -266,10 +275,13 @@ export class TranslationBatchManager {
 				);
 			}
 
-			const skippedForValidTranslationPullRequest = await this.skipIfValidTranslationPullRequest(
+			const pullRequestValidity = await this.translationPullRequestValidity.evaluate(file.path);
+
+			const skippedForValidTranslationPullRequest = this.skipIfValidTranslationPullRequest(
 				file,
 				metadata,
 				startTime,
+				pullRequestValidity,
 			);
 
 			if (skippedForValidTranslationPullRequest) {
@@ -277,14 +289,14 @@ export class TranslationBatchManager {
 			}
 
 			const branchStart = Date.now();
-			metadata.branch = await this.resetTranslationBranch(file);
+			metadata.branch = await this.prepareTranslationBranch(file, pullRequestValidity);
 			file.logger.debug(
 				{ branchRef: metadata.branch.ref, durationMs: Date.now() - branchStart },
 				"Step 1/5: Translation branch reset for single-commit workflow",
 			);
 
 			const translationStart = Date.now();
-			const translationResult = await this.services.translator.translateContent(file);
+			const translationResult = await this.resolveTranslation(file, pullRequestValidity);
 			metadata.translation = translationResult.content;
 			metadata.retries = translationResult.retries;
 			file.logger.debug(
@@ -292,6 +304,7 @@ export class TranslationBatchManager {
 					translationSize: metadata.translation.length,
 					durationMs: Date.now() - translationStart,
 					retryCount: metadata.retries.length,
+					remediationKind: translationResult.remediationKind,
 				},
 				"Step 3/5: Translation complete",
 			);
@@ -332,7 +345,11 @@ export class TranslationBatchManager {
 			file.logger.debug({ durationMs: Date.now() - commitStart }, "Step 4/5: Commit complete");
 
 			const prStart = Date.now();
-			const pullRequestOutcome = await this.openTranslationPullRequest(file, metadata);
+			const pullRequestOutcome = await this.openTranslationPullRequest(
+				file,
+				metadata,
+				pullRequestValidity,
+			);
 			metadata.pullRequest = pullRequestOutcome.pullRequest;
 			metadata.pullRequestProgress = pullRequestOutcome.progress;
 			file.logger.debug(
@@ -403,21 +420,83 @@ export class TranslationBatchManager {
 	}
 
 	/**
+	 * Resolves translated content: maintainer tiers first when applicable, otherwise full re-translation.
+	 *
+	 * @param file Upstream English source file for the workflow
+	 * @param validity Pull request validity from the start of file processing
+	 *
+	 * @returns Translated content, retries, and which remediation tier ran
+	 */
+	private async resolveTranslation(
+		file: TranslationFile,
+		validity: TranslationPullRequestValidity,
+	) {
+		if (validity.invalidReason !== "needs_maintainer_fix" || !validity.pullRequest) {
+			const result = await this.services.translator.translateContent(file);
+
+			return { ...result, remediationKind: "full" as const };
+		}
+
+		const branchName = getTranslationBranchNameFromPath(file.path);
+		const [forkContent, comments, runnerCommitAt] = await Promise.all([
+			this.services.github.getForkFileContentAtBranch(file.path, branchName),
+			this.services.github.listPullRequestIssueComments(validity.pullRequest.number),
+			this.services.github.getLatestTranslationCommitTimestamp(branchName),
+		]);
+
+		if (!forkContent?.trim()) {
+			const result = await this.services.translator.translateContent(file);
+
+			return { ...result, remediationKind: "full" as const };
+		}
+
+		const commentBodies = getMaintainerFeedbackCommentBodies(comments, runnerCommitAt);
+		const remediated = await this.maintainerFeedbackRemediation.tryRemediate(
+			forkContent,
+			file.content,
+			commentBodies,
+			file,
+		);
+
+		if (remediated) {
+			file.logger.info(
+				{ path: file.path, prNumber: validity.pullRequest.number, kind: remediated.kind },
+				"Applied maintainer feedback remediation",
+			);
+
+			return {
+				content: remediated.content,
+				retries: remediated.retries,
+				remediationKind: remediated.kind,
+			};
+		}
+
+		file.logger.info(
+			{ path: file.path, prNumber: validity.pullRequest.number },
+			"No targeted maintainer remediation; falling back to full re-translation",
+		);
+
+		const result = await this.services.translator.translateContent(file);
+
+		return { ...result, remediationKind: "full" as const };
+	}
+
+	/**
 	 * Returns completed metadata when an open translation pull request is already valid.
 	 *
 	 * @param file Translation file being processed
 	 * @param metadata In-progress processing result to populate when skipping
 	 * @param startTime Workflow step start time for duration logging
+	 * @param validity Pull request validity evaluated at the start of file processing
 	 *
 	 * @returns Filled metadata when skipped, or `null` to continue translation
 	 */
-	private async skipIfValidTranslationPullRequest(
+	private skipIfValidTranslationPullRequest(
 		file: TranslationFile,
 		metadata: ProcessedFileResult,
 		startTime: number,
+		validity: TranslationPullRequestValidity,
 	) {
-		const validity = await this.translationPullRequestValidity.evaluate(file.path);
-
 		if (!validity.isValid || !validity.pullRequest) {
 			return null;
 		}
@@ -479,6 +558,40 @@ export class TranslationBatchManager {
 	}
 
 	/**
+	 * Resolves the fork branch for translation: reuses an existing branch when addressing
+	 * maintainer feedback, otherwise resets from the fork default tip.
+	 *
+	 * @param file Translation file being processed
+	 * @param validity Pull request validity from the start of file processing
+	 *
+	 * @returns Branch reference to commit the translation on
+	 */
+	private async prepareTranslationBranch(
+		file: TranslationFile,
+		validity: TranslationPullRequestValidity,
+	) {
+		if (validity.invalidReason === "needs_maintainer_fix" && validity.pullRequest) {
+			const branchName = getTranslationBranchNameFromPath(file.path);
+			const existingBranch = await this.services.github.getBranch(branchName);
+
+			if (existingBranch) {
+				this.logger.info(
+					{
+						filename: file.filename,
+						prNumber: validity.pullRequest.number,
+						branchName,
+					},
+					"Reusing translation branch for maintainer feedback remediation",
+				);
+
+				return existingBranch.data;
+			}
+		}
+
+		return this.resetTranslationBranch(file);
+	}
+
+	/**
 	 * Closes any open translation PR and recreates the branch from the fork default tip.
 	 *
 	 * Ensures the subsequent translation commit is the only commit on the topic branch.
@@ -529,16 +642,33 @@ export class TranslationBatchManager {
 	 *
 	 * @param file Translation file being processed
 	 * @param processingResult Processing metadata including translation and timing
+	 * @param validity Pull request validity evaluated at the start of file processing
 	 *
-	 * @returns Newly created pull request metadata for progress reporting
+	 * @returns Pull request metadata for progress reporting
 	 */
 	private async openTranslationPullRequest(
 		file: TranslationFile,
 		processingResult: ProcessedFileResult,
+		validity: TranslationPullRequestValidity,
 	): Promise<{
 		pullRequest: NonNullable<ProcessedFileResult["pullRequest"]>;
-		progress: PullRequestProgressAction.Created;
+		progress: PullRequestProgressAction;
 	}> {
+		if (validity.invalidReason === "needs_maintainer_fix" && validity.pullRequest) {
+			this.logger.info(
+				{
+					path: file.path,
+					prNumber: validity.pullRequest.number,
+				},
+				"Keeping open translation pull request after maintainer feedback remediation",
+			);
+
+			return {
+				pullRequest: validity.pullRequest,
+				progress: PullRequestProgressAction.Reused,
+			};
+		}
+
 		const branchName = getTranslationBranchNameFromPath(file.path);
 		const languageName = this.services.languageDetector.getLanguageName(
 			this.services.languageDetector.languages.target,

--- a/src/app/services/runner/workflow/translation-pull-request-validity.manager.ts
+++ b/src/app/services/runner/workflow/translation-pull-request-validity.manager.ts
@@ -6,8 +6,17 @@ import type { RunnerServiceDependencies } from "../runner.types";
 
 import { getTranslationBranchNameFromPath, logger } from "@/app/utils/";
 
+import {
+	hasMaintainerFeedbackAfterRunnerCommit,
+	isMaintainerFeedbackComment,
+} from "./maintainer-feedback.util";
+
 /** Why an open translation pull request is not treated as workflow-complete */
-export type TranslationPullRequestInvalidReason = "no_open_pr" | "out_of_sync" | "not_translated";
+export type TranslationPullRequestInvalidReason =
+	| "no_open_pr"
+	| "out_of_sync"
+	| "not_translated"
+	| "needs_maintainer_fix";
 
 /** Outcome of evaluating an open translation pull request for a repository path */
 export interface TranslationPullRequestValidity {
@@ -28,7 +37,8 @@ export interface TranslationPullRequestValidity {
  * Decides whether an open translation PR already satisfies the workflow for a path.
  *
  * Valid when there is an open PR on the `translate/…` branch, fork content is in the
- * target language, and the PR is in sync with its base (no merge conflicts).
+ * target language, the PR is in sync with its base (no merge conflicts), and no maintainer
+ * left review feedback on the PR after the latest runner translation commit.
  */
 export class TranslationPullRequestValidityManager {
 	private readonly logger = logger.child({
@@ -117,6 +127,30 @@ export class TranslationPullRequestValidityManager {
 			};
 		}
 
+		const maintainerFeedback = await this.detectUnresolvedMaintainerFeedback(
+			openPullRequest.number,
+			branchName,
+		);
+
+		if (maintainerFeedback) {
+			this.logger.debug(
+				{
+					filePath,
+					prNumber: openPullRequest.number,
+					latestRunnerCommitAt: maintainerFeedback.latestRunnerCommitAt?.toISOString(),
+					maintainerCommentAt: maintainerFeedback.maintainerCommentAt.toISOString(),
+				},
+				"Translation pull request has maintainer feedback after the latest runner commit",
+			);
+
+			return {
+				isValid: false,
+				pullRequest: openPullRequest,
+				invalidReason: "needs_maintainer_fix",
+				pullRequestStatus,
+			};
+		}
+
 		this.logger.debug(
 			{
 				filePath,
@@ -131,5 +165,38 @@ export class TranslationPullRequestValidityManager {
 			pullRequest: openPullRequest,
 			pullRequestStatus,
 		};
+	}
+
+	/**
+	 * Detects maintainer issue comments posted after the latest runner commit on the branch.
+	 *
+	 * @param prNumber Open translation pull request number
+	 * @param branchName Fork branch backing the pull request
+	 *
+	 * @returns Feedback timing when unresolved maintainer comments exist, otherwise `undefined`
+	 */
+	private async detectUnresolvedMaintainerFeedback(prNumber: number, branchName: string) {
+		const [comments, latestRunnerCommitAt] = await Promise.all([
+			this.services.github.listPullRequestIssueComments(prNumber),
+			this.services.github.getLatestTranslationCommitTimestamp(branchName),
+		]);
+
+		if (!hasMaintainerFeedbackAfterRunnerCommit(comments, latestRunnerCommitAt)) {
+			return undefined;
+		}
+
+		const maintainerCommentAt = comments
+			.filter(
+				(comment) =>
+					latestRunnerCommitAt !== undefined &&
+					isMaintainerFeedbackComment(comment) &&
+					comment.createdAt > latestRunnerCommitAt,
+			)
+			.reduce(
+				(latest, comment) => (comment.createdAt > latest ? comment.createdAt : latest),
+				latestRunnerCommitAt ?? new Date(0),
+			);
+
+		return { latestRunnerCommitAt, maintainerCommentAt };
 	}
 }

--- a/src/app/services/translator/pipeline/translation-pipeline.manager.ts
+++ b/src/app/services/translator/pipeline/translation-pipeline.manager.ts
@@ -43,6 +43,9 @@ export interface TranslationPipelineRunParams {
 		translatedContent: string,
 		issues: TranslationValidationIssue[],
 	) => ApplicationError;
+
+	/** Attempt context for the first translation try (e.g. maintainer feedback hints) */
+	initialAttemptContext?: TranslationAttemptContext;
 }
 
 /**
@@ -64,9 +67,16 @@ export class TranslationPipelineManager {
 	public async translateWithValidationRetries(
 		params: TranslationPipelineRunParams,
 	): Promise<TranslationPipelineResult> {
-		const { file, translateBody, finalizeTranslation, collectIssues, createFailedError } = params;
+		const {
+			file,
+			translateBody,
+			finalizeTranslation,
+			collectIssues,
+			createFailedError,
+			initialAttemptContext = emptyTranslationAttemptContext(),
+		} = params;
 
-		let attemptContext = emptyTranslationAttemptContext();
+		let attemptContext = initialAttemptContext;
 		let translatedContent = "";
 		const retries: TranslationRetryInfo[] = [];
 

--- a/src/app/services/translator/translator.service.ts
+++ b/src/app/services/translator/translator.service.ts
@@ -38,7 +38,10 @@ import {
 	mergePreservedYamlFrontmatter,
 	splitLeadingYamlFrontmatter,
 } from "./markdown/frontmatter";
-import { emptyTranslationAttemptContext } from "./pipeline/translation-attempt.context";
+import {
+	emptyTranslationAttemptContext,
+	translationAttemptContextFromHints,
+} from "./pipeline/translation-attempt.context";
 import { TranslationPipelineManager } from "./pipeline/translation-pipeline.manager";
 import { validateAndReassembleChunks } from "./postprocess/chunk-reassembly";
 import { cleanupTranslatedContent } from "./postprocess/translation-output-cleanup";
@@ -55,6 +58,12 @@ export type {
 } from "./llm/translation-system-prompt.types";
 
 export type { TranslationRetryInfo } from "./validation/validation.types";
+
+/** Optional inputs for {@link TranslatorService.translateContent} */
+export interface TranslateContentOptions {
+	/** Extra retry hints from maintainer review (section-scoped remediation) */
+	readonly validationRetryHints?: readonly string[];
+}
 
 /** Result from translating a file, including retry metadata */
 export interface TranslationResult {
@@ -340,6 +349,7 @@ export class TranslatorService {
 	 * 8. Cleans up and returns translated content
 	 *
 	 * @param file File containing content to translate
+	 * @param options Optional maintainer retry hints for the first attempt
 	 *
 	 * @returns Promise resolving to translated content
 	 *
@@ -358,7 +368,10 @@ export class TranslatorService {
 	 * console.log(translated); // '# Olá\n\nBem-vindo ao React!'
 	 * ```
 	 */
-	public async translateContent(file: TranslationFile): Promise<TranslationResult> {
+	public async translateContent(
+		file: TranslationFile,
+		options?: TranslateContentOptions,
+	): Promise<TranslationResult> {
 		file.logger.info({ file: file.getLogContext() }, "Translating content for file");
 
 		if (!file.content.length) {
@@ -418,10 +431,16 @@ export class TranslatorService {
 		const sourceBodyForArtifacts =
 			fileBodySplit.rest.length > 0 ? fileBodySplit.rest : file.content;
 
+		const initialAttemptContext =
+			options?.validationRetryHints?.length ?
+				translationAttemptContextFromHints(options.validationRetryHints)
+			:	emptyTranslationAttemptContext();
+
 		const pipelineResult = await this.managers.pipeline.translateWithValidationRetries({
 			file,
 			translateBody: (attemptContext) =>
 				this.translateMarkdownBody(translationWorkFile, attemptContext),
+			initialAttemptContext,
 			finalizeTranslation: async (bodyTranslation) => {
 				let finalized = bodyTranslation;
 

--- a/tests/mocks/services.mock.ts
+++ b/tests/mocks/services.mock.ts
@@ -112,6 +112,8 @@ export function createMockGitHubService() {
 				state: "closed",
 			} as RestEndpointMethodTypes["pulls"]["update"]["response"]["data"]),
 		),
+		listPullRequestIssueComments: mock(() => Promise.resolve([])),
+		getLatestTranslationCommitTimestamp: mock(() => Promise.resolve(undefined)),
 		commentCompiledResultsOnIssue: mock(() => Promise.resolve({ id: 1 })),
 	};
 }

--- a/tests/services/runner/maintainer-feedback-remediation.manager.spec.ts
+++ b/tests/services/runner/maintainer-feedback-remediation.manager.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { MaintainerFeedbackRemediationManager } from "@/app/services/runner/workflow/maintainer-feedback-remediation.manager";
+
+import { createTranslationFileFixture } from "@tests/fixtures";
+
+const PR_1227_COMMENT = `\
+\`\`\`diff
+-## Solução de problemas {/*troubleshooting*/}
++## Solução de Problemas {/*troubleshooting*/}
+\`\`\``;
+
+describe("MaintainerFeedbackRemediationManager", () => {
+	test("applies mechanical remediation without calling the translator", async () => {
+		const translateContent = mock(() =>
+			Promise.resolve({ content: "should not run", retries: [] }),
+		);
+		const manager = new MaintainerFeedbackRemediationManager({
+			translateContent,
+		} as never);
+		const file = createTranslationFileFixture();
+		const forkContent = "## Solução de problemas {/*troubleshooting*/}\n\nCorpo.";
+
+		const result = await manager.tryRemediate(forkContent, file.content, [PR_1227_COMMENT], file);
+
+		expect(result?.kind).toBe("mechanical");
+		expect(result?.content).toContain("Solução de Problemas");
+		expect(translateContent).not.toHaveBeenCalled();
+	});
+
+	test("uses section-scoped translation when mechanical fixes do not apply", async () => {
+		const translateContent = mock(() =>
+			Promise.resolve({
+				content: "### Desativando uma animação {/*opting-out-of-an-animation*/}\nNovo.\n",
+				retries: [],
+			}),
+		);
+		const manager = new MaintainerFeedbackRemediationManager({
+			translateContent,
+		} as never);
+		const file = createTranslationFileFixture({
+			content: `\
+# Doc
+
+### Opting-out of an animation {/*opting-out-of-an-animation*/}
+You can use the class "none" to opt-out.
+`,
+		});
+		const forkContent = `\
+# Doc
+
+### Otimizando para fora de uma animação {/*opting-out-of-an-animation*/}
+Você pode usar a classe "none" para otimizar para fora de uma animação.
+`;
+		const comment = "Corrija `{/*opting-out-of-an-animation*/}` nesta seção.";
+
+		const result = await manager.tryRemediate(forkContent, file.content, [comment], file);
+
+		expect(result?.kind).toBe("section");
+		expect(translateContent).toHaveBeenCalled();
+		expect(result?.content).toContain("Desativando uma animação");
+	});
+});

--- a/tests/services/runner/maintainer-feedback.util.spec.ts
+++ b/tests/services/runner/maintainer-feedback.util.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+
+import type { PullRequestIssueCommentSnapshot } from "@/app/services/github/types";
+
+import {
+	hasMaintainerFeedbackAfterRunnerCommit,
+	isMaintainerFeedbackComment,
+} from "@/app/services/runner/workflow/maintainer-feedback.util";
+
+function comment(
+	overrides: Partial<PullRequestIssueCommentSnapshot> &
+		Pick<PullRequestIssueCommentSnapshot, "createdAt">,
+): PullRequestIssueCommentSnapshot {
+	return {
+		login: "jhonmike",
+		authorAssociation: "MEMBER",
+		userType: "User",
+		body: "",
+		...overrides,
+	};
+}
+
+describe("maintainer-feedback.util", () => {
+	describe("isMaintainerFeedbackComment", () => {
+		test("returns true for repository member comments", () => {
+			expect(
+				isMaintainerFeedbackComment(comment({ createdAt: new Date("2026-06-03T12:00:00Z") })),
+			).toBe(true);
+		});
+
+		test("returns false for bot and ignored automation logins", () => {
+			expect(
+				isMaintainerFeedbackComment(
+					comment({
+						login: "vercel[bot]",
+						userType: "Bot",
+						createdAt: new Date("2026-06-03T12:00:00Z"),
+					}),
+				),
+			).toBe(false);
+			expect(
+				isMaintainerFeedbackComment(
+					comment({
+						login: "github-actions[bot]",
+						userType: "Bot",
+						createdAt: new Date("2026-06-03T12:00:00Z"),
+					}),
+				),
+			).toBe(false);
+		});
+
+		test("returns false for drive-by contributor comments", () => {
+			expect(
+				isMaintainerFeedbackComment(
+					comment({
+						authorAssociation: "CONTRIBUTOR",
+						createdAt: new Date("2026-06-03T12:00:00Z"),
+					}),
+				),
+			).toBe(false);
+		});
+	});
+
+	describe("hasMaintainerFeedbackAfterRunnerCommit", () => {
+		const runnerCommitAt = new Date("2026-06-03T10:00:00Z");
+
+		test("returns true when a maintainer commented after the runner commit", () => {
+			const comments = [comment({ createdAt: new Date("2026-06-03T11:30:00Z") })];
+
+			expect(hasMaintainerFeedbackAfterRunnerCommit(comments, runnerCommitAt)).toBe(true);
+		});
+
+		test("returns false when maintainer feedback predates the runner commit", () => {
+			const comments = [comment({ createdAt: new Date("2026-06-03T09:00:00Z") })];
+
+			expect(hasMaintainerFeedbackAfterRunnerCommit(comments, runnerCommitAt)).toBe(false);
+		});
+
+		test("returns false when no runner commit baseline exists", () => {
+			const comments = [comment({ createdAt: new Date("2026-06-03T11:30:00Z") })];
+
+			expect(hasMaintainerFeedbackAfterRunnerCommit(comments, undefined)).toBe(false);
+		});
+	});
+});

--- a/tests/services/runner/maintainer-mechanical-fix.util.spec.ts
+++ b/tests/services/runner/maintainer-mechanical-fix.util.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	applyMechanicalLineReplacements,
+	parseMechanicalLineReplacements,
+} from "@/app/services/runner/workflow/maintainer-mechanical-fix.util";
+
+const PR_1227_COMMENT = `\
+\`\`\`diff
+-## Solução de problemas {/*troubleshooting*/}
++## Solução de Problemas {/*troubleshooting*/}
+\`\`\``;
+
+const PR_1238_COMMENT = `\
+**Traduzido (com o bug):**
+\`\`\`
+### Otimizando para fora de uma animação {/*opting-out-of-an-animation*/}
+Você pode usar a classe "none" para otimizar para fora de uma animação.
+\`\`\`
+
+Sugestão de correção:
+\`\`\`
+### Desativando uma animação {/*opting-out-of-an-animation*/}
+Você pode usar a classe "none" para desativar uma animação.
+\`\`\``;
+
+describe("maintainer-mechanical-fix.util", () => {
+	test("parses single-line diff hunks from maintainer comments", () => {
+		const replacements = parseMechanicalLineReplacements([PR_1227_COMMENT]);
+
+		expect(replacements).toEqual([
+			{
+				search: "## Solução de problemas {/*troubleshooting*/}",
+				replace: "## Solução de Problemas {/*troubleshooting*/}",
+			},
+		]);
+	});
+
+	test("parses suggestion blocks that replace a buggy translated excerpt", () => {
+		const replacements = parseMechanicalLineReplacements([PR_1238_COMMENT]);
+
+		expect(replacements).toHaveLength(1);
+		expect(replacements[0]?.search).toContain("Otimizando para fora");
+		expect(replacements[0]?.replace).toContain("Desativando uma animação");
+	});
+
+	test("applies replacements only when the search string is unique", () => {
+		const content = "## Solução de problemas {/*troubleshooting*/}\n\nTexto.";
+		const replacements = parseMechanicalLineReplacements([PR_1227_COMMENT]);
+		const result = applyMechanicalLineReplacements(content, replacements);
+
+		expect(result.appliedCount).toBe(1);
+		expect(result.content).toContain("## Solução de Problemas {/*troubleshooting*/}");
+	});
+});

--- a/tests/services/runner/markdown-section.util.spec.ts
+++ b/tests/services/runner/markdown-section.util.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	extractFirstHeadingSlug,
+	extractMarkdownSectionBySlug,
+	replaceMarkdownSectionBySlug,
+} from "@/app/services/runner/workflow/markdown-section.util";
+
+describe("markdown-section.util", () => {
+	const document = `\
+# Title
+
+## Intro
+
+### Opting-out of an animation {/*opting-out-of-an-animation*/}
+You can use the class "none" to opt-out.
+
+### Next section {/*next*/}
+More text.
+`;
+
+	test("extracts a section by heading slug", () => {
+		const slice = extractMarkdownSectionBySlug(document, "opting-out-of-an-animation");
+
+		expect(slice?.section).toContain("### Opting-out of an animation");
+		expect(slice?.section).toContain('class "none"');
+		expect(slice?.suffix).toContain("### Next section");
+	});
+
+	test("replaces a section by heading slug", () => {
+		const updated = replaceMarkdownSectionBySlug(
+			document,
+			"opting-out-of-an-animation",
+			"### Desativando uma animação {/*opting-out-of-an-animation*/}\nNovo texto.\n",
+		);
+
+		expect(updated).toContain("### Desativando uma animação");
+		expect(updated).toContain("### Next section");
+		expect(updated).not.toContain("### Opting-out of an animation");
+	});
+
+	test("extracts the first slug from maintainer comment text", () => {
+		expect(
+			extractFirstHeadingSlug("Na seção `### Opting-out` {/*opting-out-of-an-animation*/}"),
+		).toBe("opting-out-of-an-animation");
+	});
+});

--- a/tests/services/runner/translation-batch.manager.spec.ts
+++ b/tests/services/runner/translation-batch.manager.spec.ts
@@ -111,5 +111,135 @@ describe("TranslationBatchManager", () => {
 			expect(github.commitTranslation).toHaveBeenCalled();
 			expect(github.createPullRequest).toHaveBeenCalled();
 		});
+
+		test("applies mechanical maintainer diff without full re-translation", async () => {
+			const github = createMockGitHubService();
+			const translator = createMockTranslatorService();
+			const languageDetector = createMockLanguageDetectorService();
+			const existingPR = createMockPullRequestListItem(1227);
+			const diffComment = `\
+\`\`\`diff
+-## Solução de problemas {/*troubleshooting*/}
++## Solução de Problemas {/*troubleshooting*/}
+\`\`\``;
+			const forkContent = "## Solução de problemas {/*troubleshooting*/}\n\nCorpo em português.";
+
+			github.findPullRequestByBranch.mockResolvedValue(existingPR);
+			github.checkPullRequestStatus.mockResolvedValue({
+				hasConflicts: false,
+				mergeable: true,
+				needsUpdate: false,
+				mergeableState: "clean",
+				createdBy: "translate-react-bot",
+			});
+			github.getForkFileContentAtBranch.mockResolvedValue(forkContent);
+			github.getLatestTranslationCommitTimestamp.mockResolvedValue(
+				new Date("2026-06-03T10:00:00Z") as never,
+			);
+			github.listPullRequestIssueComments.mockResolvedValue([
+				{
+					login: "jhonmike",
+					authorAssociation: "MEMBER",
+					userType: "User",
+					createdAt: new Date("2026-06-03T12:00:00Z"),
+					body: diffComment,
+				},
+			] as never);
+			github.getBranch.mockResolvedValue({
+				data: { ref: "refs/heads/translate/test", object: { sha: "branch-sha" } },
+			} as never);
+			languageDetector.analyzeLanguage.mockResolvedValue({
+				isTranslated: true,
+				ratio: 0.9,
+				detectedLanguage: "pt",
+				languageScore: { target: 0.9, source: 0.1 },
+				rawResult: { reliable: true, languages: [], textBytes: 100, chunks: [] },
+			} as never);
+
+			const manager = createTestTranslationBatchManager({
+				github: github as unknown as RunnerServiceDependencies["github"],
+				translator: translator as unknown as RunnerServiceDependencies["translator"],
+				languageDetector:
+					languageDetector as unknown as RunnerServiceDependencies["languageDetector"],
+			});
+			const file = createTranslationFileFixture({
+				path: "src/content/reference/react/target.md",
+				filename: "target.md",
+				content: "## Troubleshooting\n\nEnglish body.",
+			});
+
+			const results = await manager.processBatches([file], 1);
+
+			expect(translator.translateContent).not.toHaveBeenCalled();
+			expect(github.commitTranslation).toHaveBeenCalled();
+			expect(results.get(file.filename)?.translation).toContain("Solução de Problemas");
+		});
+
+		test("reprocesses maintainer feedback without closing the pull request or resetting the branch", async () => {
+			const github = createMockGitHubService();
+			const translator = createMockTranslatorService();
+			const languageDetector = createMockLanguageDetectorService();
+			const existingPR = createMockPullRequestListItem(1208);
+			const existingBranchRef = {
+				ref: "refs/heads/translate/src-content-blog-post",
+				object: { sha: "branch-sha-before-fix" },
+			};
+
+			github.findPullRequestByBranch.mockResolvedValue(existingPR);
+			github.checkPullRequestStatus.mockResolvedValue({
+				hasConflicts: false,
+				mergeable: true,
+				needsUpdate: false,
+				mergeableState: "clean",
+				createdBy: "translate-react-bot",
+			});
+			github.getForkFileContentAtBranch.mockResolvedValue(
+				"Conteúdo em português suficientemente longo para detecção de idioma.",
+			);
+			github.getLatestTranslationCommitTimestamp.mockResolvedValue(
+				new Date("2026-06-03T10:00:00Z") as never,
+			);
+			github.listPullRequestIssueComments.mockResolvedValue([
+				{
+					login: "jhonmike",
+					authorAssociation: "MEMBER",
+					userType: "User",
+					createdAt: new Date("2026-06-03T12:00:00Z"),
+					body: "Please review the heading case in this file.",
+				},
+			] as never);
+			github.getBranch.mockResolvedValue({ data: existingBranchRef });
+			languageDetector.analyzeLanguage.mockResolvedValue({
+				isTranslated: true,
+				ratio: 0.9,
+				detectedLanguage: "pt",
+				languageScore: { target: 0.9, source: 0.1 },
+				rawResult: { reliable: true, languages: [], textBytes: 100, chunks: [] },
+			} as never);
+
+			const manager = createTestTranslationBatchManager({
+				github: github as unknown as RunnerServiceDependencies["github"],
+				translator: translator as unknown as RunnerServiceDependencies["translator"],
+				languageDetector:
+					languageDetector as unknown as RunnerServiceDependencies["languageDetector"],
+			});
+			const file = createTranslationFileFixture({
+				path: "src/content/blog/2021/12/17/react-conf-2021-recap.md",
+				filename: "react-conf-2021-recap.md",
+			});
+
+			const results = await manager.processBatches([file], 1);
+
+			expect(translator.translateContent).toHaveBeenCalled();
+			expect(github.commitTranslation).toHaveBeenCalled();
+			expect(github.closePullRequest).not.toHaveBeenCalled();
+			expect(github.deleteBranch).not.toHaveBeenCalled();
+			expect(github.createBranch).not.toHaveBeenCalled();
+			expect(github.createPullRequest).not.toHaveBeenCalled();
+			expect(results.get(file.filename)?.pullRequest).toEqual(existingPR);
+			expect(results.get(file.filename)?.pullRequestProgress).toBe(
+				PullRequestProgressAction.Reused,
+			);
+		});
 	});
 });

--- a/tests/services/runner/translation-pull-request-validity.manager.spec.ts
+++ b/tests/services/runner/translation-pull-request-validity.manager.spec.ts
@@ -115,4 +115,52 @@ describe("TranslationPullRequestValidityManager", () => {
 		expect(result.isValid).toBe(false);
 		expect(result.invalidReason).toBe("not_translated");
 	});
+
+	test("returns needs_maintainer_fix when maintainer commented after the latest runner commit", async () => {
+		const github = createMockGitHubService();
+		const languageDetector = createMockLanguageDetectorService();
+
+		github.findPullRequestByBranch.mockResolvedValue(createMockPullRequestListItem(55));
+		github.checkPullRequestStatus.mockResolvedValue({
+			hasConflicts: false,
+			mergeable: true,
+			needsUpdate: false,
+			mergeableState: "clean",
+			createdBy: "translate-react-bot",
+		});
+		github.getForkFileContentAtBranch.mockResolvedValue(
+			"Texto em português com comprimento suficiente para análise linguística confiável.",
+		);
+		github.getLatestTranslationCommitTimestamp.mockResolvedValue(
+			new Date("2026-06-03T10:00:00Z") as never,
+		);
+		github.listPullRequestIssueComments.mockResolvedValue([
+			{
+				login: "jhonmike",
+				authorAssociation: "MEMBER",
+				userType: "User",
+				createdAt: new Date("2026-06-03T12:00:00Z"),
+				body: "Please fix the heading.",
+			},
+		] as never);
+		languageDetector.analyzeLanguage.mockResolvedValue({
+			isTranslated: true,
+			ratio: 0.95,
+			detectedLanguage: "pt",
+			languageScore: { target: 0.95, source: 0.05 },
+			rawResult: { reliable: true, languages: [], textBytes: 100, chunks: [] },
+		} as never);
+
+		const manager = createValidityManager({
+			github: github as unknown as RunnerServiceDependencies["github"],
+			languageDetector:
+				languageDetector as unknown as RunnerServiceDependencies["languageDetector"],
+		});
+
+		const result = await manager.evaluate("src/content/reference/react/legacy.md");
+
+		expect(result.isValid).toBe(false);
+		expect(result.invalidReason).toBe("needs_maintainer_fix");
+		expect(result.pullRequest?.number).toBe(55);
+	});
 });


### PR DESCRIPTION
- Treat member comments after the latest `docs: translate` commit as `needs_maintainer_fix`
- Apply mechanical `diff`/suggestion patches, then section re-translation with slug hints, then full re-translate
- Keep the open PR and `translate/…` branch when remediating review feedback
- Add GitHub PR comment and fork commit helpers; optional `validationRetryHints` on `translateContent`

Closes #46

<!-- Keep the title in Conventional Commits form, e.g. `feat(services): add upstream poller`. -->

## Summary

<!-- What changes and why. Link related issues with `closes #123`. -->

## Changes

-

## Checklist

- [ ] `bun run lint` and `bun run format` pass
- [ ] `bun run type-check` passes
- [ ] `bun test` passes
- [ ] Conventional Commit title and messages
- [ ] If `package.json` `version` changed, `CHANGELOG.md` has a matching `## [version]` section (CI enforces this)
- [ ] Docs updated (README / Wiki) when behavior or config changed
