### PR TITLE
feat(validation): add pt-br glossary terminology guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 - Maintainer feedback workflow: detect member review after the latest runner commit, apply mechanical `diff`/suggestion patches or section-scoped re-translation with comment hints, then fall back to full re-translation; reuse branch and PR instead of reset.
 - pt-br fenced-code policy: locale rules, prompt scope override, and `fencePreservedDemoContent` guard for demo UI strings and React terms in code comments.
+- pt-br glossary terminology: `glossaryTerminology` guard with glossary parsing, protected product names, intra-document consistency checks, and locale prompt rules.
 
 ### Fixed
 

--- a/src/app/constants/index.ts
+++ b/src/app/constants/index.ts
@@ -1,5 +1,6 @@
 export * from "./error-messages.constants";
 export * from "./maintainer-feedback.constants";
+export * from "./pt-br-terminology.constants";
 export * from "./environment.constants";
 export * from "./rate-limit.constants";
 export * from "./react-translation.constants";

--- a/src/app/constants/pt-br-terminology.constants.ts
+++ b/src/app/constants/pt-br-terminology.constants.ts
@@ -1,0 +1,82 @@
+import type {
+	ProtectedEnglishTermRule,
+	TerminologyConsistencyRule,
+	TerminologyEnforcementRule,
+} from "@/app/services/translator/validation/analyzers/terminology.types";
+
+/**
+ * pt-br terminology rules beyond upstream glossary tables (maintainer review evidence).
+ *
+ * @see {@link https://github.com/NivaldoFarias/translate-react/issues/47}
+ */
+export const PT_BR_TERMINOLOGY_ENFORCEMENT_RULES: readonly TerminologyEnforcementRule[] = [
+	{
+		sourcePattern: new RegExp(/\btroubleshooting\b/i),
+		forbiddenInTranslation: [new RegExp(/\bSolução de problemas\b/)],
+		preferredTranslation: "Solução de Problemas",
+		glossaryHint:
+			'Glossary: "troubleshooting" → "solução de problemas"; use title case "Solução de Problemas" in headings.',
+	},
+	{
+		sourcePattern: new RegExp(/\breset(?:s|ting|ted)?\b/i),
+		forbiddenInTranslation: [new RegExp(/\bresetar\b/i), new RegExp(/\bresetou\b/i)],
+		preferredTranslation: "redefinir",
+		glossaryHint: 'Use "redefinir" for "reset"; do not use "resetar".',
+	},
+	{
+		sourcePattern: new RegExp(/\bopt(?:ing)?-out\b/i),
+		forbiddenInTranslation: [new RegExp(/otimizar para fora/i)],
+		preferredTranslation: "desativar (opt-out)",
+		glossaryHint:
+			'"opt-out" means opting out of a feature; use "desativar" or keep "opt-out", not "otimizar para fora".',
+	},
+];
+
+/**
+ * Official React product names that must stay in English in pt-br docs when cited in source.
+ */
+export const PT_BR_PROTECTED_ENGLISH_TERMS: readonly ProtectedEnglishTermRule[] = [
+	{
+		term: "React Server Components",
+		sourcePattern: new RegExp(/\bReact Server Components\b/),
+		forbiddenLiteralTranslations: [
+			new RegExp(/Componentes de Servidor React/i),
+			new RegExp(/Componentes do Servidor React/i),
+		],
+	},
+	{
+		term: "Flight",
+		sourcePattern: new RegExp(/\b(?:React )?Flight\b/i),
+		requireVerbatimEnglish: false,
+		forbiddenLiteralTranslations: [new RegExp(/\bVoo\b/)],
+	},
+	{
+		term: "Effect Event",
+		sourcePattern: new RegExp(/\bEffect Events?\b/),
+		requireVerbatimEnglish: false,
+		forbiddenLiteralTranslations: [new RegExp(/Eventos? de Efeito/i)],
+	},
+];
+
+/**
+ * Intra-document consistency rules for repeated English anchors (chunk-boundary drift).
+ */
+export const PT_BR_TERMINOLOGY_CONSISTENCY_RULES: readonly TerminologyConsistencyRule[] = [
+	{
+		sourcePattern: new RegExp(/\bwiring\b/i),
+		conflictingForms: ["lógica de conexão", "lógica"],
+		glossaryHint:
+			'Pick one rendering for "wiring" in this file (e.g. always "lógica de conexão" or always "lógica").',
+	},
+	{
+		sourcePattern: new RegExp(/\bEffect Events?\b/),
+		conflictingForms: [
+			"Evento de Effect",
+			"Evento de Efeito",
+			"Eventos de Effect",
+			"Eventos de Efeito",
+		],
+		glossaryHint:
+			'Use one form for "Effect Event" throughout (prefer "Evento de Effect" or keep "Effect Event").',
+	},
+];

--- a/src/app/locales/pt-br.locale.ts
+++ b/src/app/locales/pt-br.locale.ts
@@ -96,7 +96,13 @@ export const ptBrLocale: LocaleDefinition = {
 - Inside fenced code blocks: do NOT translate string literals or JSX text used as demo UI copy (labels like \`Created at:\`, button text, \`<h1>\` headings in examples). Copy them exactly from the source in English.
 - Keep React API vocabulary in \`//\` and \`/* */\` code comments in English (\`state\`, \`effect\`, \`ref\`, \`props\`, \`reducer\`, \`dispatch\`, \`context\`, \`memo\`, \`render\`, \`suspense\`, etc.) unless the translation guidelines explicitly map the term.
 - When you translate a code comment into Portuguese, translate the full comment. Do not mix English words into Portuguese sentences except for official API names from the list above.
-- \`<ConsoleLogLine>\` and similar MDX console output: keep message text in English to match runtime console output; do not localize error strings.`,
+- \`<ConsoleLogLine>\` and similar MDX console output: keep message text in English to match runtime console output; do not localize error strings.
+
+## TERMINOLOGY (pt-br.react.dev)
+- Apply upstream \`GLOSSARY.md\` terms consistently in every section and chunk (e.g. "reset" → "redefinir", not "resetar"; "troubleshooting" → "Solução de Problemas" with capital P in headings).
+- Keep official product names in English when cited: "React Server Components", "React Flight" / "Flight" (never "Voo"), "Effect Event" (prefer "Evento de Effect" or English; never "Evento de Efeito").
+- "opt-out" means opting out of a feature: use "desativar" or keep "opt-out"; never "otimizar para fora".
+- Use one Portuguese rendering per English concept in the same file (do not mix "lógica" and "lógica de conexão" for "wiring").`,
 	},
 	pullRequest: {
 		title: (file: TranslationFile) => `Tradução de \`${file.filename}\` para Português (Brasil)`,

--- a/src/app/services/translator/translator.service.ts
+++ b/src/app/services/translator/translator.service.ts
@@ -180,7 +180,9 @@ export class TranslatorService {
 		this.managers = {
 			chunks: new ChunksManager(this.model),
 			pipeline: new TranslationPipelineManager(),
-			validation: new PostTranslationValidationService(),
+			validation: new PostTranslationValidationService({
+				getTranslationGuidelines: () => this.translationGuidelines,
+			}),
 			languageCheck: new TranslationLanguageCheck(this.services.languageDetector),
 		};
 		this.promptBuilder = new TranslationPromptBuilder(

--- a/src/app/services/translator/validation/analyzers/glossary-markdown.parser.ts
+++ b/src/app/services/translator/validation/analyzers/glossary-markdown.parser.ts
@@ -1,0 +1,125 @@
+import type { TerminologyEnforcementRule } from "./terminology.types";
+
+const GLOSSARY_TABLE_ROW = new RegExp(/^\|\s*(?<english>[^|]+?)\s*\|\s*(?<portuguese>[^|]+?)\s*\|/);
+
+const GLOSSARY_TABLE_SEPARATOR = new RegExp(/^\|\s*[-:| ]+\s*\|/);
+
+/**
+ * Parses markdown glossary tables into enforcement rules for forbidden alternate renderings.
+ *
+ * @param glossaryMarkdown Raw `GLOSSARY.md` or equivalent guidelines text
+ *
+ * @returns Rules derived from `| English | Portuguese |` rows
+ */
+export function parseGlossaryMarkdownEnforcementRules(glossaryMarkdown: string) {
+	const rules: TerminologyEnforcementRule[] = [];
+
+	for (const line of glossaryMarkdown.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed.startsWith("|") || GLOSSARY_TABLE_SEPARATOR.test(trimmed)) continue;
+
+		const match = GLOSSARY_TABLE_ROW.exec(trimmed);
+		if (!match?.groups) continue;
+
+		const english = match.groups["english"]?.trim() ?? "";
+		const portuguese = match.groups["portuguese"]?.trim() ?? "";
+		if (!english || !portuguese || /^palavra|termo|original|sugestão/i.test(english)) {
+			continue;
+		}
+
+		const primaryPortuguese = portuguese.split(/[,(]/)[0]?.trim() ?? portuguese;
+		if (primaryPortuguese.length < 2) continue;
+
+		const englishPattern = buildEnglishGlossaryPattern(english);
+
+		rules.push({
+			sourcePattern: englishPattern,
+			forbiddenInTranslation: [],
+			preferredTranslation: primaryPortuguese,
+			glossaryHint: `Glossary: "${english}" → "${primaryPortuguese}".`,
+		});
+
+		const alternatePortuguese = extractAlternatePortugueseForms(portuguese, primaryPortuguese);
+		if (alternatePortuguese.length === 0) continue;
+
+		const rule = rules.at(-1);
+		if (!rule) continue;
+
+		rules[rules.length - 1] = {
+			...rule,
+			forbiddenInTranslation: alternatePortuguese.map(
+				(form) => new RegExp(`\\b${escapeRegExpLiteral(form)}\\b`, "i"),
+			),
+		};
+	}
+
+	return rules;
+}
+
+/**
+ * Merges parsed glossary rules with static pt-br rules, deduplicating by English anchor text.
+ *
+ * @param glossaryMarkdown Upstream glossary file contents
+ * @param staticRules Locale-specific enforcement rules
+ *
+ * @returns Combined rule list (static rules win on duplicate English keys)
+ */
+export function mergeTerminologyEnforcementRules(
+	glossaryMarkdown: string | null | undefined,
+	staticRules: readonly TerminologyEnforcementRule[],
+) {
+	const parsed = glossaryMarkdown ? parseGlossaryMarkdownEnforcementRules(glossaryMarkdown) : [];
+	const byEnglishKey = new Map<string, TerminologyEnforcementRule>();
+
+	for (const rule of parsed) {
+		byEnglishKey.set(rule.glossaryHint, rule);
+	}
+
+	for (const rule of staticRules) {
+		byEnglishKey.set(rule.glossaryHint, rule);
+	}
+
+	return [...byEnglishKey.values()];
+}
+
+/**
+ * Builds a word-boundary RegExp for an English glossary row label
+ *
+ * @param english English glossary row label
+ *
+ * @returns RegExp pattern for the English glossary row label
+ */
+function buildEnglishGlossaryPattern(english: string) {
+	const normalized = english.trim();
+	return new RegExp(`\\b${escapeRegExpLiteral(normalized)}\\b`, "i");
+}
+
+/**
+ * Pulls alternate Portuguese forms from parenthetical glossary hints
+ *
+ * @param portugueseCell Parenthetical glossary hints
+ * @param primary Primary Portuguese form
+ *
+ * @returns Alternate Portuguese forms
+ */
+function extractAlternatePortugueseForms(portugueseCell: string, primary: string) {
+	const parentheticalPattern = new RegExp(/\(([^)]+)\)/);
+	const parenthetical = parentheticalPattern.exec(portugueseCell)?.[1];
+	if (!parenthetical) return [];
+
+	return parenthetical
+		.split(/[/,]/)
+		.map((part) => part.trim())
+		.filter((part) => part.length > 1 && part.toLowerCase() !== primary.toLowerCase());
+}
+
+/**
+ * Escapes a string for use inside a RegExp literal
+ *
+ * @param value Raw string to escape
+ *
+ * @returns Escaped string for `RegExp` construction
+ */
+function escapeRegExpLiteral(value: string) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/app/services/translator/validation/analyzers/markdown-prose.util.ts
+++ b/src/app/services/translator/validation/analyzers/markdown-prose.util.ts
@@ -1,0 +1,17 @@
+import { MARKDOWN_REGEXES } from "@/app/services/translator/markdown/markdown.regexes";
+
+/**
+ * Returns markdown with fenced blocks and inline code removed for prose terminology checks.
+ *
+ * @param markdown Full markdown document
+ *
+ * @returns Prose-only text (headings and paragraphs retained)
+ */
+export function stripMarkdownForTerminologyProse(markdown: string) {
+	let prose = markdown.replace(MARKDOWN_REGEXES.codeBlock, " ");
+	prose = prose.replace(MARKDOWN_REGEXES.frontmatter, " ");
+	prose = prose.replace(new RegExp(/`[^`\n]+`/g), " ");
+	prose = prose.replace(new RegExp(/!\[[^\]]*]\([^)]*\)/g), " ");
+	prose = prose.replace(new RegExp(/\[[^\]]*]\([^)]*\)/g), " ");
+	return prose;
+}

--- a/src/app/services/translator/validation/analyzers/terminology.analyzer.ts
+++ b/src/app/services/translator/validation/analyzers/terminology.analyzer.ts
@@ -1,0 +1,167 @@
+import type { TerminologyViolation } from "./terminology.types";
+
+import {
+	PT_BR_PROTECTED_ENGLISH_TERMS,
+	PT_BR_TERMINOLOGY_CONSISTENCY_RULES,
+	PT_BR_TERMINOLOGY_ENFORCEMENT_RULES,
+} from "@/app/constants/pt-br-terminology.constants";
+
+import { mergeTerminologyEnforcementRules } from "./glossary-markdown.parser";
+import { stripMarkdownForTerminologyProse } from "./markdown-prose.util";
+
+/**
+ * Finds glossary and locale terminology violations in translated prose.
+ *
+ * @param sourceMarkdown Original markdown
+ * @param translatedMarkdown Translated markdown
+ * @param glossaryMarkdown Optional upstream glossary text
+ *
+ * @returns Violations with retry hints
+ */
+export function findGlossaryTerminologyViolations(
+	sourceMarkdown: string,
+	translatedMarkdown: string,
+	glossaryMarkdown?: string | null,
+) {
+	const sourceProse = stripMarkdownForTerminologyProse(sourceMarkdown);
+	const translatedProse = stripMarkdownForTerminologyProse(translatedMarkdown);
+	const rules = mergeTerminologyEnforcementRules(
+		glossaryMarkdown,
+		PT_BR_TERMINOLOGY_ENFORCEMENT_RULES,
+	);
+
+	const violations: TerminologyViolation[] = [];
+
+	for (const rule of rules) {
+		if (!rule.sourcePattern.test(sourceProse)) continue;
+
+		for (const forbidden of rule.forbiddenInTranslation) {
+			if (!forbidden.test(translatedProse)) continue;
+
+			const match = translatedProse.match(forbidden)?.[0] ?? "forbidden term";
+			violations.push({
+				kind: "glossary",
+				message: `Forbidden terminology "${match}"`,
+				glossaryHint:
+					rule.preferredTranslation ?
+						`${rule.glossaryHint} Prefer "${rule.preferredTranslation}".`
+					:	rule.glossaryHint,
+			});
+			break;
+		}
+	}
+
+	return violations;
+}
+
+/**
+ * Flags literal translations of official React product names that must stay in English.
+ *
+ * @param sourceMarkdown Original markdown
+ * @param translatedMarkdown Translated markdown
+ *
+ * @returns Violations when protected names were translated or mistranslated
+ */
+export function findProtectedTermViolations(sourceMarkdown: string, translatedMarkdown: string) {
+	const sourceProse = stripMarkdownForTerminologyProse(sourceMarkdown);
+	const translatedProse = stripMarkdownForTerminologyProse(translatedMarkdown);
+	const violations: TerminologyViolation[] = [];
+
+	for (const rule of PT_BR_PROTECTED_ENGLISH_TERMS) {
+		if (!rule.sourcePattern.test(sourceProse)) continue;
+
+		const requireEnglish = rule.requireVerbatimEnglish !== false;
+
+		if (requireEnglish && !translatedProse.includes(rule.term)) {
+			violations.push({
+				kind: "protected",
+				message: `Protected term "${rule.term}" must stay in English`,
+				glossaryHint: `Keep "${rule.term}" in English; do not translate product or API names.`,
+			});
+			continue;
+		}
+
+		for (const forbidden of rule.forbiddenLiteralTranslations ?? []) {
+			if (!forbidden.test(translatedProse)) continue;
+
+			const match = translatedProse.match(forbidden)?.[0] ?? "forbidden translation";
+			violations.push({
+				kind: "protected",
+				message: `Literal translation "${match}" for protected term "${rule.term}"`,
+				glossaryHint: `Keep "${rule.term}" in English; do not use "${match}".`,
+			});
+			break;
+		}
+	}
+
+	return violations;
+}
+
+/**
+ * Detects multiple Portuguese renderings for the same repeated English anchor in one file.
+ *
+ * @param sourceMarkdown Original markdown
+ * @param translatedMarkdown Translated markdown
+ *
+ * @returns Violations when chunk boundaries likely caused terminology drift
+ */
+export function findTerminologyConsistencyViolations(
+	sourceMarkdown: string,
+	translatedMarkdown: string,
+) {
+	const sourceProse = stripMarkdownForTerminologyProse(sourceMarkdown);
+	const translatedProse = stripMarkdownForTerminologyProse(translatedMarkdown);
+	const violations: TerminologyViolation[] = [];
+
+	for (const rule of PT_BR_TERMINOLOGY_CONSISTENCY_RULES) {
+		const sourceMatches = sourceProse.match(new RegExp(rule.sourcePattern, "gi")) ?? [];
+		if (sourceMatches.length < 2) continue;
+
+		const formsPresent = rule.conflictingForms.filter((form) =>
+			translatedProse.toLowerCase().includes(form.toLowerCase()),
+		);
+
+		if (formsPresent.length < 2) continue;
+
+		violations.push({
+			kind: "consistency",
+			message: `Inconsistent renderings for the same concept: ${formsPresent.join(" vs ")}`,
+			glossaryHint: rule.glossaryHint,
+		});
+	}
+
+	return violations;
+}
+
+/**
+ * Builds a combined retry hint from terminology violations.
+ *
+ * @param violations Issues from glossary, protected-term, and consistency analyzers
+ *
+ * @returns Hint string for the LLM system prompt
+ */
+export function buildTerminologyRetryHint(violations: readonly TerminologyViolation[]) {
+	const hints = [...new Set(violations.map((violation) => violation.glossaryHint))];
+	return hints.slice(0, 4).join(" ");
+}
+
+/**
+ * Runs all pt-br terminology analyzers.
+ *
+ * @param sourceMarkdown Original markdown
+ * @param translatedMarkdown Translated markdown
+ * @param glossaryMarkdown Optional upstream glossary
+ *
+ * @returns Combined violations
+ */
+export function findAllTerminologyViolations(
+	sourceMarkdown: string,
+	translatedMarkdown: string,
+	glossaryMarkdown?: string | null,
+) {
+	return [
+		...findGlossaryTerminologyViolations(sourceMarkdown, translatedMarkdown, glossaryMarkdown),
+		...findProtectedTermViolations(sourceMarkdown, translatedMarkdown),
+		...findTerminologyConsistencyViolations(sourceMarkdown, translatedMarkdown),
+	];
+}

--- a/src/app/services/translator/validation/analyzers/terminology.types.ts
+++ b/src/app/services/translator/validation/analyzers/terminology.types.ts
@@ -1,0 +1,51 @@
+/** One glossary or locale terminology enforcement rule */
+export interface TerminologyEnforcementRule {
+	/** English anchor in source; rule skipped when this does not match prose */
+	readonly sourcePattern: RegExp;
+
+	/** Portuguese substrings that must not appear in translation when the source matches */
+	readonly forbiddenInTranslation: readonly RegExp[];
+
+	/** Portuguese form that should appear instead (for retry hints only) */
+	readonly preferredTranslation?: string;
+
+	/** Short citation for LLM retry hints (glossary line or locale rule) */
+	readonly glossaryHint: string;
+}
+
+/** English term that must remain untranslated when present in source prose */
+export interface ProtectedEnglishTermRule {
+	/** Literal English product or API name */
+	readonly term: string;
+
+	/** Word-boundary pattern to detect the term in source prose */
+	readonly sourcePattern: RegExp;
+
+	/**
+	 * When `true`, translation must still contain {@link ProtectedEnglishTermRule.term} verbatim.
+	 * When `false`, only {@link ProtectedEnglishTermRule.forbiddenLiteralTranslations} are checked.
+	 */
+	readonly requireVerbatimEnglish?: boolean;
+
+	/** Literal Portuguese mistranslations to reject (e.g. Flight → Voo) */
+	readonly forbiddenLiteralTranslations?: readonly RegExp[];
+}
+
+/** Flags when multiple allowed renderings for one English anchor appear in the same file */
+export interface TerminologyConsistencyRule {
+	/** English anchor that must appear at least twice in source prose */
+	readonly sourcePattern: RegExp;
+
+	/** Distinct Portuguese renderings; violation when two or more appear in translation */
+	readonly conflictingForms: readonly string[];
+
+	/** Hint text for LLM retry */
+	readonly glossaryHint: string;
+}
+
+/** One terminology violation surfaced by an analyzer */
+export interface TerminologyViolation {
+	readonly kind: "glossary" | "protected" | "consistency";
+	readonly message: string;
+	readonly glossaryHint: string;
+}

--- a/src/app/services/translator/validation/guards/glossary-terminology.guard.ts
+++ b/src/app/services/translator/validation/guards/glossary-terminology.guard.ts
@@ -1,0 +1,44 @@
+import type { PostTranslationValidationGuard } from "../validation.types";
+
+import { env } from "@/app/utils/";
+
+import {
+	buildTerminologyRetryHint,
+	findAllTerminologyViolations,
+} from "../analyzers/terminology.analyzer";
+
+/**
+ * Rejects pt-br translations that violate glossary, protected-term, or consistency rules.
+ *
+ * @param source Original markdown before translation
+ * @param translated Model output to validate
+ * @param options Optional validation context including upstream glossary text
+ *
+ * @returns Guard failure with retry hint, or `null` when terminology checks pass
+ */
+export const glossaryTerminologyGuard: PostTranslationValidationGuard = (
+	source,
+	translated,
+	options,
+) => {
+	if (env.TARGET_LANGUAGE !== "pt-br") return null;
+
+	const violations = findAllTerminologyViolations(
+		source,
+		translated,
+		options?.translationGuidelines,
+	);
+
+	if (violations.length === 0) return null;
+
+	const summary = violations
+		.slice(0, 3)
+		.map((violation) => violation.message)
+		.join("; ");
+
+	return {
+		guardId: "glossaryTerminology",
+		message: `Terminology: ${summary}`,
+		retryHint: buildTerminologyRetryHint(violations),
+	};
+};

--- a/src/app/services/translator/validation/guards/index.ts
+++ b/src/app/services/translator/validation/guards/index.ts
@@ -1,4 +1,7 @@
-import type { TranslationValidationIssue } from "../validation.types";
+import type {
+	PostTranslationValidationOptions,
+	TranslationValidationIssue,
+} from "../validation.types";
 
 import { env } from "@/app/utils/";
 
@@ -6,6 +9,7 @@ import { contentRatioGuard } from "./content-ratio.guard";
 import { fenceFunctionIdentifiersGuard } from "./fence-function-identifiers.guard";
 import { fencePreservedDemoContentGuard } from "./fence-preserved-demo-content.guard";
 import { frontmatterPreservedGuard } from "./frontmatter-preserved.guard";
+import { glossaryTerminologyGuard } from "./glossary-terminology.guard";
 import { headingsPreservedGuard } from "./headings-preserved.guard";
 import { nonEmptyContentGuard } from "./non-empty-content.guard";
 
@@ -16,7 +20,9 @@ export const POST_TRANSLATION_VALIDATION_GUARDS = [
 	headingsPreservedGuard,
 	frontmatterPreservedGuard,
 	fenceFunctionIdentifiersGuard,
-	...(env.TARGET_LANGUAGE === "pt-br" ? [fencePreservedDemoContentGuard] : []),
+	...(env.TARGET_LANGUAGE === "pt-br" ?
+		[fencePreservedDemoContentGuard, glossaryTerminologyGuard]
+	:	[]),
 ] as const;
 
 /**
@@ -24,17 +30,19 @@ export const POST_TRANSLATION_VALIDATION_GUARDS = [
  *
  * @param sourceContent Original markdown
  * @param translatedContent Translated markdown
+ * @param options Optional glossary and locale context for terminology guards
  *
  * @returns Retryable issues with accumulated hints
  */
 export function collectPostTranslationValidationIssues(
 	sourceContent: string,
 	translatedContent: string,
+	options?: PostTranslationValidationOptions,
 ) {
 	const issues: TranslationValidationIssue[] = [];
 
 	for (const guard of POST_TRANSLATION_VALIDATION_GUARDS) {
-		const issue = guard(sourceContent, translatedContent);
+		const issue = guard(sourceContent, translatedContent, options);
 		if (issue) issues.push(issue);
 	}
 

--- a/src/app/services/translator/validation/post-translation-validation.service.ts
+++ b/src/app/services/translator/validation/post-translation-validation.service.ts
@@ -1,6 +1,9 @@
 import type { TranslationFile } from "../translation-file";
 
-import type { TranslationValidationIssue } from "./validation.types";
+import type {
+	PostTranslationValidationOptions,
+	TranslationValidationIssue,
+} from "./validation.types";
 
 import { collectTopLevelKeysFromInnerYaml } from "@/app/services/translator/markdown/frontmatter";
 import { ApplicationError, ErrorCode } from "@/shared/errors";
@@ -12,10 +15,25 @@ import { VALIDATION_RATIOS } from "./validation.constants";
 
 export type { TranslationValidationIssue } from "./validation.types";
 
+/** Dependencies for {@link PostTranslationValidationService} */
+export interface PostTranslationValidationServiceDependencies {
+	/** Upstream glossary markdown when loaded on the translator */
+	readonly getTranslationGuidelines?: () => string | null;
+}
+
 /**
  * Runs post-translation guards and records soft validation warnings.
  */
 export class PostTranslationValidationService {
+	private readonly getTranslationGuidelines: () => string | null;
+
+	/**
+	 * @param dependencies Optional glossary provider for terminology guards
+	 */
+	constructor(dependencies: PostTranslationValidationServiceDependencies = {}) {
+		this.getTranslationGuidelines = dependencies.getTranslationGuidelines ?? (() => null);
+	}
+
 	/**
 	 * Runs post-translation guards that can trigger an LLM retry with hints.
 	 *
@@ -28,7 +46,9 @@ export class PostTranslationValidationService {
 		file: TranslationFile,
 		translatedContent: string,
 	): TranslationValidationIssue[] {
-		return collectPostTranslationValidationIssues(file.content, translatedContent);
+		return collectPostTranslationValidationIssues(file.content, translatedContent, {
+			translationGuidelines: this.getTranslationGuidelines(),
+		} satisfies PostTranslationValidationOptions);
 	}
 
 	/**

--- a/src/app/services/translator/validation/validation.types.ts
+++ b/src/app/services/translator/validation/validation.types.ts
@@ -10,10 +10,17 @@ export interface TranslationValidationIssue extends TranslationRetryInfo {
 	retryHint: string;
 }
 
+/** Optional context for post-translation guards */
+export interface PostTranslationValidationOptions {
+	/** Upstream glossary markdown (`GLOSSARY.md`) when loaded */
+	readonly translationGuidelines?: string | null;
+}
+
 /**
  * Post-translation check that may return a retryable issue with an LLM hint.
  */
 export type PostTranslationValidationGuard = (
 	sourceContent: string,
 	translatedContent: string,
+	options?: PostTranslationValidationOptions,
 ) => TranslationValidationIssue | null;

--- a/tests/services/translator/validation/analyzers/glossary-markdown.parser.spec.ts
+++ b/tests/services/translator/validation/analyzers/glossary-markdown.parser.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseGlossaryMarkdownEnforcementRules } from "@/app/services/translator/validation/analyzers/glossary-markdown.parser";
+
+describe("glossary-markdown.parser", () => {
+	test("parseGlossaryMarkdownEnforcementRules reads translation table rows", () => {
+		const glossary = `
+## Traduções Comuns
+
+| Palavra/Termo original | Sugestão |
+| ---------------------- | -------- |
+| troubleshooting        | solução de problemas |
+| render                 | renderizar (verb), renderizado (noun) |
+`;
+
+		const rules = parseGlossaryMarkdownEnforcementRules(glossary);
+
+		expect(rules.some((rule) => rule.glossaryHint.includes("troubleshooting"))).toBe(true);
+		expect(rules.some((rule) => rule.glossaryHint.includes("renderizar"))).toBe(true);
+	});
+});

--- a/tests/services/translator/validation/analyzers/terminology.analyzer.spec.ts
+++ b/tests/services/translator/validation/analyzers/terminology.analyzer.spec.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	findAllTerminologyViolations,
+	findGlossaryTerminologyViolations,
+	findProtectedTermViolations,
+	findTerminologyConsistencyViolations,
+} from "@/app/services/translator/validation/analyzers/terminology.analyzer";
+import { glossaryTerminologyGuard } from "@/app/services/translator/validation/guards/glossary-terminology.guard";
+
+describe("terminology.analyzer", () => {
+	test("findGlossaryTerminologyViolations flags Solução de problemas heading (pt-br #1227)", () => {
+		const source = `
+## Troubleshooting {/*troubleshooting*/}
+
+Fix common issues.
+`;
+
+		const translated = `
+## Solução de problemas {/*troubleshooting*/}
+
+Corrija problemas comuns.
+`;
+
+		const violations = findGlossaryTerminologyViolations(source, translated);
+
+		expect(violations.some((violation) => violation.kind === "glossary")).toBe(true);
+		expect(violations[0]?.glossaryHint).toContain("Solução de Problemas");
+	});
+
+	test("findGlossaryTerminologyViolations flags resetar when source uses reset (pt-br #1200)", () => {
+		const source = `
+You can reset state when the form unmounts.
+`;
+
+		const translated = `
+Você pode resetar o estado quando o formulário desmonta.
+`;
+
+		const violations = findGlossaryTerminologyViolations(source, translated);
+
+		expect(violations.some((violation) => violation.message.includes("resetar"))).toBe(true);
+		expect(violations[0]?.glossaryHint).toContain("redefinir");
+	});
+
+	test("findProtectedTermViolations flags Flight translated as Voo (pt-br #1203)", () => {
+		const source = `
+React Flight streams UI to the client.
+`;
+
+		const translated = `
+O Voo do React envia UI para o cliente.
+`;
+
+		const violations = findProtectedTermViolations(source, translated);
+
+		expect(violations.some((violation) => violation.kind === "protected")).toBe(true);
+		expect(violations[0]?.message).toContain("Voo");
+	});
+
+	test("findProtectedTermViolations flags translated React Server Components (pt-br #1194)", () => {
+		const source = `
+<BlogCard title="React Server Components" />
+`;
+
+		const translated = `
+<BlogCard title="Componentes de Servidor React" />
+`;
+
+		const violations = findProtectedTermViolations(source, translated);
+
+		expect(
+			violations.some((violation) => violation.message.includes("React Server Components")),
+		).toBe(true);
+	});
+
+	test("findTerminologyConsistencyViolations flags mixed wiring renderings (pt-br #1206)", () => {
+		const source = `
+## Wiring state
+
+Later sections discuss wiring again.
+`;
+
+		const translated = `
+## Lógica de estado
+
+Mais adiante, a lógica de conexão aparece de novo.
+`;
+
+		const violations = findTerminologyConsistencyViolations(source, translated);
+
+		expect(violations.some((violation) => violation.kind === "consistency")).toBe(true);
+	});
+
+	test("findProtectedTermViolations flags Evento de Efeito for Effect Event (pt-br #1208)", () => {
+		const source = `
+## Effect Event
+
+Limitations of Effect Events.
+`;
+
+		const translated = `
+## Evento de Effect
+
+Limitações dos Eventos de Efeito.
+`;
+
+		const violations = findProtectedTermViolations(source, translated);
+
+		expect(violations.some((violation) => violation.message.includes("Efeito"))).toBe(true);
+	});
+
+	test("findTerminologyConsistencyViolations flags Effect Event vs Evento de Efeito (pt-br #1208)", () => {
+		const source = `
+## Effect Event
+
+Limitations of Effect Events.
+`;
+
+		const translated = `
+## Evento de Effect
+
+Limitações dos Eventos de Efeito.
+`;
+
+		const violations = findTerminologyConsistencyViolations(source, translated);
+
+		expect(violations.length).toBeGreaterThan(0);
+	});
+
+	test("glossaryTerminologyGuard returns retry hint for opt-out mistranslation (pt-br #1238)", () => {
+		const source = `
+### Opting-out of View Transitions
+`;
+
+		const translated = `
+### Otimizar para fora das View Transitions
+`;
+
+		const issue = glossaryTerminologyGuard(source, translated);
+
+		expect(issue?.guardId).toBe("glossaryTerminology");
+		expect(issue?.retryHint).toContain("desativar");
+	});
+
+	test("findAllTerminologyViolations passes when glossary terms are applied consistently", () => {
+		const source = `
+## Troubleshooting
+
+Reset the form.
+`;
+
+		const translated = `
+## Solução de Problemas
+
+Redefina o formulário.
+`;
+
+		expect(findAllTerminologyViolations(source, translated)).toEqual([]);
+	});
+});


### PR DESCRIPTION
- Add `glossaryTerminology` post-translation guard with retry hints
- Parse upstream `GLOSSARY.md` tables and enforce protected product names
- Detect intra-document terminology drift; extend `pt-br.locale` rules