### PR TITLE
feat(translator): retry pt-br slices after chunk terminology drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 - pt-br fenced-code policy: locale rules, prompt scope override, and `fencePreservedDemoContent` guard for demo UI strings and React terms in code comments.
 - pt-br glossary terminology: `glossaryTerminology` guard with glossary parsing, protected product names, intra-document consistency checks, and locale prompt rules.
 - Markdown link and pt-br heading guards: `markdownLinksPreserved` for `[text](url)` integrity, `ptBrHeadingSentenceCase` for sentence-case headings, plus locale prompt rules.
+- Chunk reassembly terminology audit: after chunked pt-br translation, detect cross-slice terminology drift and re-translate only affected slices with targeted hints before full-document validation.
 
 ### Fixed
 

--- a/src/app/services/translator/chunking/chunking.constants.ts
+++ b/src/app/services/translator/chunking/chunking.constants.ts
@@ -16,6 +16,14 @@ export const CHUNKS = {
 	 */
 	overlap: 0,
 
+	/**
+	 * Maximum translate passes over chunked markdown when slice-level terminology drift is detected.
+	 *
+	 * Initial parallel translation counts as pass one; one selective slice retry is pass two.
+	 * Further drift is left to full-document post-translation guards and pipeline retries.
+	 */
+	terminologyConsistencyMaxPasses: 2,
+
 	/** Token buffer reserved for chunk processing overhead when splitting content */
 	tokenBuffer: 500,
 

--- a/src/app/services/translator/postprocess/chunk-terminology-consistency.ts
+++ b/src/app/services/translator/postprocess/chunk-terminology-consistency.ts
@@ -1,0 +1,141 @@
+import { PT_BR_TERMINOLOGY_CONSISTENCY_RULES } from "@/app/constants/pt-br-terminology.constants";
+
+import { stripMarkdownForTerminologyProse } from "../validation/analyzers/markdown-prose.util";
+
+/** Drift detected across translated document slices after chunk reassembly */
+export interface ChunkTerminologyDrift {
+	/** English anchor that appeared in multiple source slices */
+	readonly englishAnchor: string;
+
+	/** Distinct Portuguese forms found across slices */
+	readonly conflictingForms: readonly string[];
+
+	/** Zero-based slice indices that contributed conflicting forms */
+	readonly offendingChunkIndices: readonly number[];
+
+	/** Hint for LLM retry on affected slices only */
+	readonly glossaryHint: string;
+}
+
+/**
+ * Maps each consistency-rule anchor to Portuguese forms present per translated slice.
+ *
+ * Used by {@link findChunkTerminologyConsistencyDrift}; does not run glossary forbidden-term checks.
+ *
+ * @param sourceChunks Original markdown slices from chunking
+ * @param translatedChunks Translated slices before reassembly
+ *
+ * @returns Per-rule maps of slice index to forms detected in that slice
+ */
+export function buildTerminologyFormsByChunk(
+	sourceChunks: readonly string[],
+	translatedChunks: readonly string[],
+) {
+	const maps: {
+		rule: (typeof PT_BR_TERMINOLOGY_CONSISTENCY_RULES)[number];
+		formsByChunk: Map<number, readonly string[]>;
+	}[] = [];
+
+	for (const rule of PT_BR_TERMINOLOGY_CONSISTENCY_RULES) {
+		const formsByChunk = new Map<number, readonly string[]>();
+
+		for (let index = 0; index < sourceChunks.length; index++) {
+			const sourceChunk = sourceChunks[index];
+			const translatedChunk = translatedChunks[index];
+			if (sourceChunk === undefined || translatedChunk === undefined) continue;
+
+			const sourceProse = stripMarkdownForTerminologyProse(sourceChunk);
+			if (!rule.sourcePattern.test(sourceProse)) continue;
+
+			const translatedProse = stripMarkdownForTerminologyProse(translatedChunk);
+			const forms = rule.conflictingForms.filter((form) =>
+				translatedProse.toLowerCase().includes(form.toLowerCase()),
+			);
+
+			if (forms.length > 0) {
+				formsByChunk.set(index, forms);
+			}
+		}
+
+		if (formsByChunk.size > 0) {
+			maps.push({ rule, formsByChunk });
+		}
+	}
+
+	return maps;
+}
+
+/**
+ * Detects pt-br terminology drift across translated chunks after reassembly.
+ *
+ * Complements {@link findTerminologyConsistencyViolations} on the full document: this pass
+ * records which slices to re-translate. Glossary forbidden-term checks stay in the terminology guard.
+ *
+ * Requires at least two slices. With `CHUNKS.overlap` at zero, each source span is translated once;
+ * selective slice retry avoids re-running the whole file when only boundary slices disagree.
+ *
+ * @param sourceChunks Original markdown slices
+ * @param translatedChunks Translated slices aligned with `sourceChunks`
+ *
+ * @returns Drift records with slice indices for targeted LLM retries
+ */
+export function findChunkTerminologyConsistencyDrift(
+	sourceChunks: readonly string[],
+	translatedChunks: readonly string[],
+) {
+	if (sourceChunks.length !== translatedChunks.length || sourceChunks.length < 2) {
+		return [];
+	}
+
+	const drifts: ChunkTerminologyDrift[] = [];
+
+	for (const { rule, formsByChunk } of buildTerminologyFormsByChunk(
+		sourceChunks,
+		translatedChunks,
+	)) {
+		const allFormsLower = new Set<string>();
+
+		for (const forms of formsByChunk.values()) {
+			for (const form of forms) {
+				allFormsLower.add(form.toLowerCase());
+			}
+		}
+
+		if (allFormsLower.size < 2) continue;
+
+		const conflictingForms = [
+			...new Set(
+				[...formsByChunk.values()].flatMap((forms) =>
+					forms.filter((form) => allFormsLower.has(form.toLowerCase())),
+				),
+			),
+		];
+
+		const offendingChunkIndices = [...formsByChunk.keys()].sort((left, right) => left - right);
+		const englishAnchor = rule.sourcePattern.source.replace(/\\b/g, "").replace(/\\/g, "");
+
+		drifts.push({
+			englishAnchor,
+			conflictingForms,
+			offendingChunkIndices,
+			glossaryHint: rule.glossaryHint,
+		});
+	}
+
+	return drifts;
+}
+
+/**
+ * Builds LLM retry hints scoped to document slices that caused terminology drift.
+ *
+ * @param drifts Output from {@link findChunkTerminologyConsistencyDrift}
+ *
+ * @returns Hints merged for the translation attempt context
+ */
+export function buildChunkTerminologyRetryHints(drifts: readonly ChunkTerminologyDrift[]) {
+	return drifts.map((drift) => {
+		const sliceList = drift.offendingChunkIndices.map((index) => index + 1).join(", ");
+		const forms = drift.conflictingForms.join(" vs ");
+		return `DOCUMENT SLICE consistency (slices ${sliceList}): for repeated "${drift.englishAnchor}" use one form, not ${forms}. ${drift.glossaryHint}`;
+	});
+}

--- a/src/app/services/translator/postprocess/index.ts
+++ b/src/app/services/translator/postprocess/index.ts
@@ -1,2 +1,3 @@
 export * from "./chunk-reassembly";
+export * from "./chunk-terminology-consistency";
 export * from "./translation-output-cleanup";

--- a/src/app/services/translator/translator.service.ts
+++ b/src/app/services/translator/translator.service.ts
@@ -28,7 +28,7 @@ import {
 import { ApplicationError, ErrorCode, isCompletionLengthTruncationError } from "@/shared/errors/";
 
 import { ChunksManager } from "./chunking";
-import { SYSTEM_PROMPT_TOKEN_RESERVE } from "./chunking/chunking.constants";
+import { CHUNKS, SYSTEM_PROMPT_TOKEN_RESERVE } from "./chunking/chunking.constants";
 import { TranslationLlmClient } from "./llm/translation-llm.client";
 import { TranslationPromptBuilder } from "./llm/translation-prompt.builder";
 import { stripSpuriousOuterMarkdownFencesWhenSourceHadNoFences } from "./markdown/artifacts";
@@ -44,6 +44,10 @@ import {
 } from "./pipeline/translation-attempt.context";
 import { TranslationPipelineManager } from "./pipeline/translation-pipeline.manager";
 import { validateAndReassembleChunks } from "./postprocess/chunk-reassembly";
+import {
+	buildChunkTerminologyRetryHints,
+	findChunkTerminologyConsistencyDrift,
+} from "./postprocess/chunk-terminology-consistency";
 import { cleanupTranslatedContent } from "./postprocess/translation-output-cleanup";
 import { TranslationFile } from "./translation-file";
 import { CONNECTIVITY_TEST_MAX_TOKENS, LLM_TEMPERATURE } from "./translator.constants";
@@ -666,8 +670,15 @@ export class TranslatorService {
 			"Content split into chunks",
 		);
 
-		const translatedChunks = await Promise.all(
+		let translatedChunks = await Promise.all(
 			chunks.map((chunk, index) => this.translateChunk(file, chunk, index, chunks, attemptContext)),
+		);
+
+		translatedChunks = await this.retryChunksWithTerminologyDrift(
+			file,
+			chunks,
+			translatedChunks,
+			attemptContext,
 		);
 
 		file.logger.debug(
@@ -680,6 +691,80 @@ export class TranslatorService {
 			translated: translatedChunks,
 			separators,
 		});
+	}
+
+	/**
+	 * Re-translates only slices that disagree on pt-br terminology after the initial chunk pass.
+	 *
+	 * @param file File under translation
+	 * @param sourceChunks Original markdown slices
+	 * @param translatedChunks Current translated slices
+	 * @param attemptContext Pipeline guard hints to preserve across slice retries
+	 *
+	 * @returns Updated translated slices (unchanged when drift is absent or locale is not pt-br)
+	 */
+	private async retryChunksWithTerminologyDrift(
+		file: TranslationFile,
+		sourceChunks: readonly string[],
+		translatedChunks: readonly string[],
+		attemptContext: TranslationAttemptContext,
+	) {
+		if (env.TARGET_LANGUAGE !== "pt-br" || sourceChunks.length < 2) {
+			return [...translatedChunks];
+		}
+
+		let currentChunks = [...translatedChunks];
+
+		for (let pass = 1; pass < CHUNKS.terminologyConsistencyMaxPasses; pass++) {
+			const drifts = findChunkTerminologyConsistencyDrift(sourceChunks, currentChunks);
+			if (drifts.length === 0) break;
+
+			const chunkIndices = [
+				...new Set(drifts.flatMap((drift) => drift.offendingChunkIndices)),
+			].sort((left, right) => left - right);
+
+			const driftHints = buildChunkTerminologyRetryHints(drifts);
+			const sliceAttemptContext = translationAttemptContextFromHints([
+				...attemptContext.validationRetryHints,
+				...driftHints,
+			]);
+
+			file.logger.warn(
+				{
+					pass,
+					maxPasses: CHUNKS.terminologyConsistencyMaxPasses,
+					chunkIndices,
+					driftCount: drifts.length,
+				},
+				"Chunk terminology drift detected; re-translating affected slices",
+			);
+
+			const retried = await Promise.all(
+				chunkIndices.map(async (index) => {
+					const sourceChunk = sourceChunks[index];
+					if (sourceChunk === undefined) return currentChunks[index] ?? "";
+
+					return this.translateChunk(
+						file,
+						sourceChunk,
+						index,
+						[...sourceChunks],
+						sliceAttemptContext,
+					);
+				}),
+			);
+
+			const nextChunks = [...currentChunks];
+			for (const [offset, index] of chunkIndices.entries()) {
+				const translated = retried[offset];
+				if (translated !== undefined) {
+					nextChunks[index] = translated;
+				}
+			}
+			currentChunks = nextChunks;
+		}
+
+		return currentChunks;
 	}
 
 	/** Reduction factor for re-chunking when a chunk hits completion token limits */

--- a/tests/services/translator/postprocess/chunk-terminology-consistency.spec.ts
+++ b/tests/services/translator/postprocess/chunk-terminology-consistency.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	buildChunkTerminologyRetryHints,
+	buildTerminologyFormsByChunk,
+	findChunkTerminologyConsistencyDrift,
+} from "@/app/services/translator/postprocess/chunk-terminology-consistency";
+
+describe("chunk-terminology-consistency", () => {
+	test("findChunkTerminologyConsistencyDrift flags wiring drift across slices (pt-br #1206)", () => {
+		const sourceChunks = [
+			"## Wiring state\n\nIntro to wiring.",
+			"Later sections discuss wiring again.",
+		];
+		const translatedChunks = [
+			"## Lógica de estado\n\nIntro.",
+			"Mais adiante, a lógica de conexão aparece de novo.",
+		];
+
+		const drifts = findChunkTerminologyConsistencyDrift(sourceChunks, translatedChunks);
+
+		expect(drifts.length).toBeGreaterThan(0);
+		expect(drifts[0]?.offendingChunkIndices).toEqual([0, 1]);
+		expect(drifts[0]?.conflictingForms.some((form) => form.includes("lógica"))).toBe(true);
+	});
+
+	test("findChunkTerminologyConsistencyDrift flags Effect Event drift across slices (pt-br #1208)", () => {
+		const sourceChunks = ["## Effect Event\n", "Limitations of Effect Events.\n"];
+		const translatedChunks = ["## Evento de Effect\n", "Limitações dos Eventos de Efeito.\n"];
+
+		const drifts = findChunkTerminologyConsistencyDrift(sourceChunks, translatedChunks);
+
+		expect(drifts.length).toBeGreaterThan(0);
+		expect(drifts[0]?.offendingChunkIndices).toEqual([0, 1]);
+	});
+
+	test("returns no drift for a single slice or matching forms across slices", () => {
+		const sourceChunks = ["## Effect Event\n", "More Effect Event text."];
+		const consistent = ["## Evento de Effect\n", "Mais texto sobre Evento de Effect."];
+
+		expect(findChunkTerminologyConsistencyDrift(["only one"], ["único"])).toEqual([]);
+		expect(findChunkTerminologyConsistencyDrift(sourceChunks, consistent)).toEqual([]);
+	});
+
+	test("buildChunkTerminologyRetryHints names slice numbers for LLM retries", () => {
+		const drifts = findChunkTerminologyConsistencyDrift(
+			["## Wiring\n", "wiring again"],
+			["## Lógica", "lógica de conexão"],
+		);
+
+		const hints = buildChunkTerminologyRetryHints(drifts);
+
+		expect(hints[0]).toContain("DOCUMENT SLICE consistency");
+		expect(hints[0]).toMatch(/slices? 1, 2/);
+	});
+
+	test("buildTerminologyFormsByChunk maps forms per slice without glossary forbidden checks", () => {
+		const maps = buildTerminologyFormsByChunk(
+			["reset state", "reset again"],
+			["resetar estado", "redefinir de novo"],
+		);
+
+		const wiringMap = maps.find((entry) => entry.rule.sourcePattern.test("wiring"));
+		expect(wiringMap).toBeUndefined();
+	});
+});


### PR DESCRIPTION
- Add `chunk-terminology-consistency` audit after chunked translation
- Re-translate only offending slices with targeted DOCUMENT SLICE hints
- Cap passes via `CHUNKS.terminologyConsistencyMaxPasses`

