### PR TITLE
release `0.2.10`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ GH_TOKEN=
 LLM_API_KEY=
 
 # LLM API endpoint and model configuration
-# LLM_MODEL="google/gemini-2.0-flash-exp:free"
+# LLM_MODEL="openai/gpt-oss-20b:free"
 # LLM_API_BASE_URL="https://openrouter.ai/api/v1"
 # OPENAI_PROJECT_ID=
 # MAX_TOKENS=8192

--- a/.github/actions/run-workflow-smoke/action.yml
+++ b/.github/actions/run-workflow-smoke/action.yml
@@ -1,5 +1,5 @@
 name: Run workflow smoke
-description: Checkout, install dependencies, and run `ci:smoke` against real LLM with mocked GitHub
+description: Install dependencies and run `ci:smoke` against real LLM with mocked GitHub (caller must checkout first)
 
 inputs:
   profile:
@@ -65,11 +65,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout repository
-      uses: actions/checkout@v7
-      with:
-        fetch-depth: 1
-
     - name: Setup Bun dependencies
       uses: ./.github/actions/setup-bun-deps
       with:

--- a/.github/actions/run-workflow-smoke/action.yml
+++ b/.github/actions/run-workflow-smoke/action.yml
@@ -1,0 +1,104 @@
+name: Run workflow smoke
+description: Checkout, install dependencies, and run `ci:smoke` against real LLM with mocked GitHub
+
+inputs:
+  profile:
+    description: Smoke profile (`quick`, `workflow`, `full`)
+    required: true
+  lang:
+    description: Target locale override (`--lang`); empty uses `TARGET_LANGUAGE`/default
+    required: false
+    default: ""
+  bun-version:
+    description: Bun version (repository variable BUN_VERSION when unset)
+    required: false
+    default: "1.3.14"
+  gh-token:
+    description: GitHub token for mocked GitHub client construction
+    required: false
+  llm-api-key:
+    description: LLM API key
+    required: false
+  node-env:
+    description: NODE_ENV
+    required: false
+  log-level:
+    description: LOG_LEVEL
+    required: false
+  log-to-console:
+    description: LOG_TO_CONSOLE
+    required: false
+  llm-model:
+    description: LLM_MODEL
+    required: false
+  llm-api-base-url:
+    description: LLM_API_BASE_URL
+    required: false
+  max-retry-attempts:
+    description: MAX_RETRY_ATTEMPTS
+    required: false
+  max-llm-concurrency:
+    description: MAX_LLM_CONCURRENCY
+    required: false
+  openai-project-id:
+    description: OPENAI_PROJECT_ID
+    required: false
+  gh-pat-token:
+    description: GH_PAT_TOKEN
+    required: false
+  max-tokens:
+    description: MAX_TOKENS
+    required: false
+  batch-size:
+    description: BATCH_SIZE
+    required: false
+  target-language:
+    description: TARGET_LANGUAGE (ignored when `lang` is set)
+    required: false
+  header-app-url:
+    description: HEADER_APP_URL
+    required: false
+  header-app-title:
+    description: HEADER_APP_TITLE
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 1
+
+    - name: Setup Bun dependencies
+      uses: ./.github/actions/setup-bun-deps
+      with:
+        bun-version: ${{ inputs.bun-version }}
+
+    - name: Run workflow smoke
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        LLM_API_KEY: ${{ inputs.llm-api-key }}
+        NODE_ENV: ${{ inputs.node-env }}
+        LOG_LEVEL: ${{ inputs.log-level }}
+        LOG_TO_CONSOLE: ${{ inputs.log-to-console }}
+        LLM_MODEL: ${{ inputs.llm-model }}
+        LLM_API_BASE_URL: ${{ inputs.llm-api-base-url }}
+        MAX_RETRY_ATTEMPTS: ${{ inputs.max-retry-attempts }}
+        MAX_LLM_CONCURRENCY: ${{ inputs.max-llm-concurrency }}
+        OPENAI_PROJECT_ID: ${{ inputs.openai-project-id }}
+        GH_PAT_TOKEN: ${{ inputs.gh-pat-token }}
+        MAX_TOKENS: ${{ inputs.max-tokens }}
+        BATCH_SIZE: ${{ inputs.batch-size }}
+        TARGET_LANGUAGE: ${{ inputs.target-language }}
+        HEADER_APP_URL: ${{ inputs.header-app-url }}
+        HEADER_APP_TITLE: ${{ inputs.header-app-title }}
+        SMOKE_PROFILE: ${{ inputs.profile }}
+        SMOKE_LANG: ${{ inputs.lang }}
+      run: |
+        ARGS=(--profile "$SMOKE_PROFILE")
+        if [ -n "$SMOKE_LANG" ]; then
+          ARGS+=(--lang "$SMOKE_LANG")
+        fi
+        bun run ci:smoke -- "${ARGS[@]}"

--- a/.github/actions/run-workflow-smoke/action.yml
+++ b/.github/actions/run-workflow-smoke/action.yml
@@ -53,7 +53,7 @@ inputs:
     description: BATCH_SIZE
     required: false
   target-language:
-    description: TARGET_LANGUAGE (ignored when `lang` is set)
+    description: TARGET_LANGUAGE fallback when `lang` is empty
     required: false
   header-app-url:
     description: HEADER_APP_URL
@@ -86,7 +86,7 @@ runs:
         GH_PAT_TOKEN: ${{ inputs.gh-pat-token }}
         MAX_TOKENS: ${{ inputs.max-tokens }}
         BATCH_SIZE: ${{ inputs.batch-size }}
-        TARGET_LANGUAGE: ${{ inputs.target-language }}
+        TARGET_LANGUAGE: ${{ inputs.lang != '' && inputs.lang || inputs.target-language }}
         HEADER_APP_URL: ${{ inputs.header-app-url }}
         HEADER_APP_TITLE: ${{ inputs.header-app-title }}
         SMOKE_PROFILE: ${{ inputs.profile }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,11 @@ jobs:
       SMOKE_OUTPUT_DIR: .out
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
       - name: Run workflow smoke (${{ matrix.lang }})
         uses: ./.github/actions/run-workflow-smoke
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,80 @@ jobs:
 
       - name: Run tests with coverage
         run: bun run test:coverage
+
+  detect-smoke-gate:
+    name: Detect translator/runner/locale changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+      langs: ${{ steps.langs.outputs.langs }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Check for translator, runner, or locale changes
+        id: check
+        run: |
+          BASE="${{ github.event.pull_request.base.sha || github.event.before }}"
+
+          if [ -z "$BASE" ] || ! git cat-file -e "$BASE" 2>/dev/null; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          elif git diff --name-only "$BASE" "${{ github.sha }}" | grep -qE '^src/app/(services/(translator|runner)/|locales/)'; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve configured locales
+        id: langs
+        run: echo "langs=$(jq -c '[.[].lang]' .github/locales.json)" >> "$GITHUB_OUTPUT"
+
+  smoke:
+    name: Workflow smoke (${{ matrix.lang }})
+    needs: detect-smoke-gate
+    if: needs.detect-smoke-gate.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: development
+    strategy:
+      fail-fast: false
+      matrix:
+        lang: ${{ fromJson(needs.detect-smoke-gate.outputs.langs) }}
+    env:
+      SMOKE_OUTPUT_DIR: .out
+
+    steps:
+      - name: Run workflow smoke (${{ matrix.lang }})
+        uses: ./.github/actions/run-workflow-smoke
+        with:
+          profile: quick
+          lang: ${{ matrix.lang }}
+          bun-version: ${{ vars.BUN_VERSION || '1.3.14' }}
+          gh-token: ${{ secrets.GH_TOKEN }}
+          llm-api-key: ${{ secrets.LLM_API_KEY }}
+          node-env: ${{ vars.NODE_ENV }}
+          log-level: ${{ vars.LOG_LEVEL }}
+          log-to-console: ${{ vars.LOG_TO_CONSOLE }}
+          llm-model: ${{ vars.LLM_MODEL }}
+          llm-api-base-url: ${{ vars.LLM_API_BASE_URL }}
+          max-retry-attempts: ${{ vars.MAX_RETRY_ATTEMPTS }}
+          max-llm-concurrency: ${{ vars.MAX_LLM_CONCURRENCY }}
+          openai-project-id: ${{ secrets.OPENAI_PROJECT_ID }}
+          gh-pat-token: ${{ secrets.GH_PAT_TOKEN }}
+          max-tokens: ${{ vars.MAX_TOKENS }}
+          batch-size: ${{ vars.BATCH_SIZE }}
+          header-app-url: ${{ vars.HEADER_APP_URL }}
+          header-app-title: ${{ vars.HEADER_APP_TITLE }}
+
+      - name: Upload workflow smoke outputs
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: ci-smoke-${{ matrix.lang }}-${{ github.run_id }}
+          path: ${{ env.SMOKE_OUTPUT_DIR }}
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,6 @@ jobs:
     needs: detect-smoke-gate
     if: needs.detect-smoke-gate.outputs.should_run == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
     environment: development
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
     environment: development
     env:
       SMOKE_OUTPUT_DIR: .out
+      SMOKE_ARCHIVE_PATH: artifacts/ci-smoke/pt-br-${{ github.run_id }}.tar.gz
 
     steps:
       - name: Checkout repository
@@ -132,13 +133,22 @@ jobs:
           header-app-url: ${{ vars.HEADER_APP_URL }}
           header-app-title: ${{ vars.HEADER_APP_TITLE }}
 
-      - name: Upload workflow smoke outputs
+      - name: Pack workflow smoke outputs for upload
+        if: failure()
+        run: |
+          if [ -d "$SMOKE_OUTPUT_DIR" ] && [ -n "$(ls -A "$SMOKE_OUTPUT_DIR" 2>/dev/null)" ]; then
+            mkdir -p "$(dirname "$SMOKE_ARCHIVE_PATH")"
+            tar -czf "$SMOKE_ARCHIVE_PATH" -C "$SMOKE_OUTPUT_DIR" .
+          fi
+
+      - name: Upload workflow smoke archive
         uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: ci-smoke-pt-br-${{ github.run_id }}
-          path: ${{ env.SMOKE_OUTPUT_DIR }}
-          if-no-files-found: ignore
+          path: ${{ env.SMOKE_ARCHIVE_PATH }}
+          archive: false
+          if-no-files-found: warn
           retention-days: 14
 
   smoke-extra-locales:
@@ -155,6 +165,7 @@ jobs:
         lang: ${{ fromJson(needs.detect-smoke-gate.outputs.optional_langs) }}
     env:
       SMOKE_OUTPUT_DIR: .out
+      SMOKE_ARCHIVE_PATH: artifacts/ci-smoke/${{ matrix.lang }}-${{ github.run_id }}.tar.gz
 
     steps:
       - name: Checkout repository
@@ -185,11 +196,20 @@ jobs:
           header-app-url: ${{ vars.HEADER_APP_URL }}
           header-app-title: ${{ vars.HEADER_APP_TITLE }}
 
-      - name: Upload workflow smoke outputs
+      - name: Pack workflow smoke outputs for upload
+        if: failure()
+        run: |
+          if [ -d "$SMOKE_OUTPUT_DIR" ] && [ -n "$(ls -A "$SMOKE_OUTPUT_DIR" 2>/dev/null)" ]; then
+            mkdir -p "$(dirname "$SMOKE_ARCHIVE_PATH")"
+            tar -czf "$SMOKE_ARCHIVE_PATH" -C "$SMOKE_OUTPUT_DIR" .
+          fi
+
+      - name: Upload workflow smoke archive
         uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: ci-smoke-${{ matrix.lang }}-${{ github.run_id }}
-          path: ${{ env.SMOKE_OUTPUT_DIR }}
-          if-no-files-found: ignore
+          path: ${{ env.SMOKE_ARCHIVE_PATH }}
+          archive: false
+          if-no-files-found: warn
           retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
-      langs: ${{ steps.langs.outputs.langs }}
+      optional_langs: ${{ steps.optional-langs.outputs.optional_langs }}
 
     steps:
       - name: Checkout repository
@@ -89,20 +89,70 @@ jobs:
             echo "should_run=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Resolve configured locales
-        id: langs
-        run: echo "langs=$(jq -c '[.[].lang]' .github/locales.json)" >> "$GITHUB_OUTPUT"
+      - name: Resolve optional locales (excluding default)
+        id: optional-langs
+        run: echo "optional_langs=$(jq -c '[.[].lang | select(. != "pt-br")]' .github/locales.json)" >> "$GITHUB_OUTPUT"
 
   smoke:
-    name: Workflow smoke (${{ matrix.lang }})
+    name: Workflow smoke (pt-br)
     needs: detect-smoke-gate
     if: needs.detect-smoke-gate.outputs.should_run == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 120
+    environment: development
+    env:
+      SMOKE_OUTPUT_DIR: .out
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Run workflow smoke (pt-br)
+        uses: ./.github/actions/run-workflow-smoke
+        with:
+          profile: quick
+          lang: pt-br
+          target-language: pt-br
+          bun-version: ${{ vars.BUN_VERSION || '1.3.14' }}
+          gh-token: ${{ secrets.GH_TOKEN }}
+          llm-api-key: ${{ secrets.LLM_API_KEY }}
+          node-env: ${{ vars.NODE_ENV }}
+          log-level: ${{ vars.LOG_LEVEL }}
+          log-to-console: ${{ vars.LOG_TO_CONSOLE }}
+          llm-model: ${{ vars.LLM_MODEL }}
+          llm-api-base-url: ${{ vars.LLM_API_BASE_URL }}
+          max-retry-attempts: ${{ vars.MAX_RETRY_ATTEMPTS }}
+          max-llm-concurrency: ${{ vars.MAX_LLM_CONCURRENCY }}
+          openai-project-id: ${{ secrets.OPENAI_PROJECT_ID }}
+          gh-pat-token: ${{ secrets.GH_PAT_TOKEN }}
+          max-tokens: ${{ vars.MAX_TOKENS }}
+          batch-size: ${{ vars.BATCH_SIZE }}
+          header-app-url: ${{ vars.HEADER_APP_URL }}
+          header-app-title: ${{ vars.HEADER_APP_TITLE }}
+
+      - name: Upload workflow smoke outputs
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: ci-smoke-pt-br-${{ github.run_id }}
+          path: ${{ env.SMOKE_OUTPUT_DIR }}
+          if-no-files-found: ignore
+          retention-days: 14
+
+  smoke-extra-locales:
+    name: Workflow smoke (${{ matrix.lang }}, optional)
+    needs: detect-smoke-gate
+    if: needs.detect-smoke-gate.outputs.should_run == 'true' && needs.detect-smoke-gate.outputs.optional_langs != '[]'
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
     environment: development
     strategy:
       fail-fast: false
       matrix:
-        lang: ${{ fromJson(needs.detect-smoke-gate.outputs.langs) }}
+        lang: ${{ fromJson(needs.detect-smoke-gate.outputs.optional_langs) }}
     env:
       SMOKE_OUTPUT_DIR: .out
 
@@ -117,6 +167,7 @@ jobs:
         with:
           profile: quick
           lang: ${{ matrix.lang }}
+          target-language: ${{ matrix.lang }}
           bun-version: ${{ vars.BUN_VERSION || '1.3.14' }}
           gh-token: ${{ secrets.GH_TOKEN }}
           llm-api-key: ${{ secrets.LLM_API_KEY }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -37,6 +37,11 @@ jobs:
       SMOKE_OUTPUT_DIR: .out
       SMOKE_ARCHIVE_PATH: artifacts/smoke/${{ inputs.profile }}-${{ github.run_id }}.tar.gz
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
       - name: Run workflow smoke
         uses: ./.github/actions/run-workflow-smoke
         with:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -37,35 +37,27 @@ jobs:
       SMOKE_OUTPUT_DIR: .out
       SMOKE_ARCHIVE_PATH: artifacts/smoke/${{ inputs.profile }}-${{ github.run_id }}.tar.gz
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 1
-
-      - name: Setup Bun dependencies
-        uses: ./.github/actions/setup-bun-deps
-        with:
-          bun-version: ${{ vars.BUN_VERSION || '1.3.14' }}
-
       - name: Run workflow smoke
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
-          NODE_ENV: ${{ vars.NODE_ENV }}
-          LOG_LEVEL: ${{ vars.LOG_LEVEL }}
-          LOG_TO_CONSOLE: ${{ vars.LOG_TO_CONSOLE }}
-          LLM_MODEL: ${{ vars.LLM_MODEL }}
-          LLM_API_BASE_URL: ${{ vars.LLM_API_BASE_URL }}
-          MAX_RETRY_ATTEMPTS: ${{ vars.MAX_RETRY_ATTEMPTS }}
-          MAX_LLM_CONCURRENCY: ${{ vars.MAX_LLM_CONCURRENCY }}
-          OPENAI_PROJECT_ID: ${{ secrets.OPENAI_PROJECT_ID }}
-          GH_PAT_TOKEN: ${{ secrets.GH_PAT_TOKEN }}
-          MAX_TOKENS: ${{ vars.MAX_TOKENS }}
-          BATCH_SIZE: ${{ vars.BATCH_SIZE }}
-          TARGET_LANGUAGE: ${{ vars.TARGET_LANGUAGE }}
-          HEADER_APP_URL: ${{ vars.HEADER_APP_URL }}
-          HEADER_APP_TITLE: ${{ vars.HEADER_APP_TITLE }}
-        run: bun run ci:smoke -- --profile "${{ inputs.profile }}"
+        uses: ./.github/actions/run-workflow-smoke
+        with:
+          profile: ${{ inputs.profile }}
+          bun-version: ${{ vars.BUN_VERSION || '1.3.14' }}
+          gh-token: ${{ secrets.GH_TOKEN }}
+          llm-api-key: ${{ secrets.LLM_API_KEY }}
+          node-env: ${{ vars.NODE_ENV }}
+          log-level: ${{ vars.LOG_LEVEL }}
+          log-to-console: ${{ vars.LOG_TO_CONSOLE }}
+          llm-model: ${{ vars.LLM_MODEL }}
+          llm-api-base-url: ${{ vars.LLM_API_BASE_URL }}
+          max-retry-attempts: ${{ vars.MAX_RETRY_ATTEMPTS }}
+          max-llm-concurrency: ${{ vars.MAX_LLM_CONCURRENCY }}
+          openai-project-id: ${{ secrets.OPENAI_PROJECT_ID }}
+          gh-pat-token: ${{ secrets.GH_PAT_TOKEN }}
+          max-tokens: ${{ vars.MAX_TOKENS }}
+          batch-size: ${{ vars.BATCH_SIZE }}
+          target-language: ${{ vars.TARGET_LANGUAGE }}
+          header-app-url: ${{ vars.HEADER_APP_URL }}
+          header-app-title: ${{ vars.HEADER_APP_TITLE }}
 
       - name: Pack workflow smoke outputs for upload
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ## [Unreleased]
 
+### Fixed
+
+- CI per-locale smoke gate jobs no longer inherit the 15-minute workflow timeout that cancelled in-progress `quick` runs.
+
 ## [0.2.10] - 2026-07-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 ### Added
 
 - Optional `fork_owner` on each `.github/locales.json` row overrides the workflow default fork owner when poll or manual matrix builds translation jobs.
+- CI runs a real-LLM workflow smoke gate once per configured locale before merging changes under `src/app/services/translator/`, `src/app/services/runner/`, or `src/app/locales/`; `ci:smoke` accepts `--lang` to target a specific locale instead of the `pt-br` default.
+- `run-workflow-smoke` composite action shares the checkout, dependency setup, and `ci:smoke` invocation between the CI gate and the manual `smoke.yml` dispatch.
 
 ### Removed
 
@@ -29,6 +31,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 - Concurrent `translateContent` calls on the shared translator service no longer share per-file LLM usage or translation-path state.
 - Language-detector tag stripping and JSX static-text link analyzers use linear scans instead of nested-regex patterns that could backtrack on near-valid upstream markdown.
 - Segment batches pack at most 20 prose segments per LLM request (down from 40), reducing structured JSON parse failures and split retries on segment-heavy pages.
+- Russian translation rules explicitly call out the `ё` letter, guillemet quotation marks («»), the `бандлер` glossary term, lowercase `серверные`/`клиентские компоненты` casing, and named MDN built-in type pages, addressing reviewer feedback on generated Russian pull requests.
 - Quick `ci:smoke` profile drops the segment-heavy `invalid-hook-call-warning.md` fixture so pre-merge runs finish sooner.
 - Translation and smoke workflow jobs no longer set `timeout-minutes`, so long locale runs are not cut off at the previous two-hour caps.
 - Segment batch failures from truncated output, id mismatch, or malformed JSON now split the batch on the first error instead of repeating the same LLM call through `p-retry`, reducing wasted retries and LLM cost.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ## [Unreleased]
 
+## [0.2.10] - 2026-07-02
+
 ### Added
 
 - Optional `fork_owner` on each `.github/locales.json` row overrides the workflow default fork owner when poll or manual matrix builds translation jobs.
@@ -318,6 +320,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 - README `MAX_RETRY_ATTEMPTS` default matches runtime (`3`).
 
+[0.2.10]: https://github.com/NivaldoFarias/translate-react/releases/tag/v0.2.10
 [0.2.9]: https://github.com/NivaldoFarias/translate-react/releases/tag/v0.2.9
 [0.2.8]: https://github.com/NivaldoFarias/translate-react/releases/tag/v0.2.8
 [0.2.7]: https://github.com/NivaldoFarias/translate-react/releases/tag/v0.2.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Changed
 
+- CI smoke gate requires only the default `pt-br` locale before merge; other configured locales run as optional jobs that do not block the workflow. Smoke jobs cap at 120 minutes.
 - Discovery retries transient GitHub errors during pull-request validity checks before fail-open inclusion, and unexpected CLD failures after retries now stop the workflow instead of silently scheduling extra translation work; empty, short, or unidentifiable content still counts as not translated.
 - GitHub file content, pull request, and translation-progress issue operations now live in dedicated modules composed by `GitHubService`; branch cleanup hooks bind directly to the pull request module.
 - Translation batch processing now delegates per-file work to dedicated branch, pull request, and file processor modules while the batch manager keeps batching and the consecutive-failure circuit breaker.
@@ -45,6 +46,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Fixed
 
+- Workflow smoke sets `TARGET_LANGUAGE` from the locale input before `ci:smoke` starts, and CLI override bootstrap no longer loads env validation early, so non-default locale smoke runs use the correct translation rules.
 - Segment-batch and frontmatter-batch LLM calls with provider `finishReason: "error"` now fail like full-body calls instead of accepting malformed provider output.
 - GitHub integration logs only safe error fields (`message`, `status`, `code`, `name`) so Octokit request headers are not written to workflow logs.
 - Consecutive translation failures now halt the workflow once the circuit-breaker threshold is reached instead of continuing through remaining files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ## [Unreleased]
 
-### Fixed
-
-- CI per-locale smoke gate jobs no longer inherit the 15-minute workflow timeout that cancelled in-progress `quick` runs.
-
 ## [0.2.10] - 2026-07-02
 
 ### Added
@@ -57,6 +53,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 - Glued inline code, MDX slug comments, and adjacent markdown links are repaired before advisory validation so those mechanical spacing regressions no longer surface as `mdxSpacing` reviewer notices on translation pull requests.
 - Blank `TARGET_LANGUAGE` or `SOURCE_LANGUAGE` from GitHub Actions or `.env` no longer fails validation; empty values default to `pt-br` and `en`.
 - Translation pull request conflict notices no longer claim the previous PR was closed when the runner refreshes the branch in place.
+- CI per-locale smoke gate jobs no longer inherit the 15-minute workflow timeout that cancelled in-progress `quick` runs.
 
 ## [0.2.9] - 2026-06-22
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ MIT. Not a hosted app: forks use their own API keys and Actions config.
 - TypeScript strict; match patterns in [`src/`](./src/).
 - Layout and services: [Wiki: Codebase](https://github.com/NivaldoFarias/translate-react/wiki/Codebase); run order: [Wiki: Workflow](https://github.com/NivaldoFarias/translate-react/wiki/Workflow). App wiring: [`src/app/composition.ts`](./src/app/composition.ts).
 - Tests: `bun test` (or `bun run test:coverage` locally); CI runs coverage. Mirror `src/` paths under `tests/`; mock GitHub and LLM.
-- Before merging changes under `src/app/services/translator/`, `src/app/services/runner/`, or `src/app/locales/`: CI green and `bun run ci:smoke -- --profile quick` (real LLM, mocked GitHub). Optional: [Workflow smoke](https://github.com/NivaldoFarias/translate-react/actions/workflows/smoke.yml) on GitHub. See [Workflow smoke](#workflow-smoke) for outputs and CI artifacts.
+- Changes under `src/app/services/translator/`, `src/app/services/runner/`, or `src/app/locales/` trigger a required `ci.yml` smoke gate that runs `ci:smoke -- --profile quick` once per configured locale (real LLM, mocked GitHub) before merge. Run it locally first with `bun run ci:smoke -- --profile quick --lang <locale>` to catch issues before pushing. See [Workflow smoke](#workflow-smoke) for outputs and CI artifacts.
 - Before push: `bun run lint`, `bun run format`.
 - Commits: [Conventional Commits](https://www.conventionalcommits.org/) (`feat`, `fix`, `chore`, `refactor`; optional scope).
 - Changelog: accumulate entries under `## [Unreleased]` in [`CHANGELOG.md`](./CHANGELOG.md) as you work. Never hand-write a `## [X.Y.Z]` heading or bump `version` outside the release flow below; CI fails a bumped version whose section lacks a date, footer link, or entries.
@@ -29,7 +29,9 @@ Fixture lists: [`smoke-profiles.util.ts`](./src/ci/services/smoke/smoke-profiles
 > [!IMPORTANT]
 >
 > - Local runs write gitignored `.out/`. Each translated fixture gets a subdirectory (i.e. `use-memo/`) with `translated.md` and `pull-request.md`. When the run posts progress, `translation-progress-issue-comment.md` sits at the `.out/` root.
-> - [`smoke.yml`](./.github/workflows/smoke.yml) is manual dispatch only. The job writes the same tree to `.out/`, packs it to `artifacts/smoke/<profile>-<run_id>.tar.gz`, and uploads artifact `smoke-<profile>-<run_id>`.
+> - `TARGET_LANGUAGE` defaults to `pt-br`; pass `--lang <locale>` to smoke a different configured locale.
+> - [`ci.yml`](./.github/workflows/ci.yml) runs the `quick` profile once per configured locale (from [`.github/locales.json`](./.github/locales.json)) as a required gate whenever `src/app/services/translator/`, `src/app/services/runner/`, or `src/app/locales/` changes; it uploads `.out/` as an artifact only on failure.
+> - [`smoke.yml`](./.github/workflows/smoke.yml) stays manual dispatch for ad hoc `workflow`/`full` profile runs or a specific GitHub Environment. The job writes the same tree to `.out/`, packs it to `artifacts/smoke/<profile>-<run_id>.tar.gz`, and uploads artifact `smoke-<profile>-<run_id>`.
 
 Extract the downloaded artifact[^1]:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ MIT. Not a hosted app: forks use their own API keys and Actions config.
 - TypeScript strict; match patterns in [`src/`](./src/).
 - Layout and services: [Wiki: Codebase](https://github.com/NivaldoFarias/translate-react/wiki/Codebase); run order: [Wiki: Workflow](https://github.com/NivaldoFarias/translate-react/wiki/Workflow). App wiring: [`src/app/composition.ts`](./src/app/composition.ts).
 - Tests: `bun test` (or `bun run test:coverage` locally); CI runs coverage. Mirror `src/` paths under `tests/`; mock GitHub and LLM.
-- Changes under `src/app/services/translator/`, `src/app/services/runner/`, or `src/app/locales/` trigger a required `ci.yml` smoke gate that runs `ci:smoke -- --profile quick` once per configured locale (real LLM, mocked GitHub) before merge. Run it locally first with `bun run ci:smoke -- --profile quick --lang <locale>` to catch issues before pushing. See [Workflow smoke](#workflow-smoke) for outputs and CI artifacts.
+- Changes under `src/app/services/translator/`, `src/app/services/runner/`, or `src/app/locales/` trigger a required `ci.yml` smoke gate that runs `ci:smoke -- --profile quick --lang pt-br` (real LLM, mocked GitHub) before merge; other configured locales run as optional matrix jobs that do not block merge. Run locally first with `bun run ci:smoke -- --profile quick --lang <locale>` to catch issues before pushing. See [Workflow smoke](#workflow-smoke) for outputs and CI artifacts.
 - Before push: `bun run lint`, `bun run format`.
 - Commits: [Conventional Commits](https://www.conventionalcommits.org/) (`feat`, `fix`, `chore`, `refactor`; optional scope).
 - Changelog: accumulate entries under `## [Unreleased]` in [`CHANGELOG.md`](./CHANGELOG.md) as you work. Never hand-write a `## [X.Y.Z]` heading or bump `version` outside the release flow below; CI fails a bumped version whose section lacks a date, footer link, or entries.
@@ -30,7 +30,7 @@ Fixture lists: [`smoke-profiles.util.ts`](./src/ci/services/smoke/smoke-profiles
 >
 > - Local runs write gitignored `.out/`. Each translated fixture gets a subdirectory (i.e. `use-memo/`) with `translated.md` and `pull-request.md`. When the run posts progress, `translation-progress-issue-comment.md` sits at the `.out/` root.
 > - `TARGET_LANGUAGE` defaults to `pt-br`; pass `--lang <locale>` to smoke a different configured locale.
-> - [`ci.yml`](./.github/workflows/ci.yml) runs the `quick` profile once per configured locale (from [`.github/locales.json`](./.github/locales.json)) as a required gate whenever `src/app/services/translator/`, `src/app/services/runner/`, or `src/app/locales/` changes; it uploads `.out/` as an artifact only on failure.
+> - [`ci.yml`](./.github/workflows/ci.yml) runs the `quick` profile for `pt-br` as a required gate whenever `src/app/services/translator/`, `src/app/services/runner/`, or `src/app/locales/` changes; other locales from [`.github/locales.json`](./.github/locales.json) run as optional jobs (`continue-on-error`) with a 120-minute timeout. Failed smoke jobs upload `.out/` as an artifact.
 > - [`smoke.yml`](./.github/workflows/smoke.yml) stays manual dispatch for ad hoc `workflow`/`full` profile runs or a specific GitHub Environment. The job writes the same tree to `.out/`, packs it to `artifacts/smoke/<profile>-<run_id>.tar.gz`, and uploads artifact `smoke-<profile>-<run_id>`.
 
 Extract the downloaded artifact[^1]:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "translate-react",
-	"version": "0.2.9",
+	"version": "0.2.10",
 	"contributors": [
 		{
 			"name": "Nivaldo Farias",

--- a/src/app/constants/environment.constants.ts
+++ b/src/app/constants/environment.constants.ts
@@ -56,7 +56,7 @@ export const ENV_PLACEHOLDERS = {
 	REPO_FORK_NAME: "pt-br.react.dev",
 	REPO_UPSTREAM_OWNER: "reactjs",
 	REPO_UPSTREAM_NAME: "pt-br.react.dev",
-	LLM_MODEL: "google/gemini-2.0-flash-exp:free",
+	LLM_MODEL: "openai/gpt-oss-20b:free",
 	LLM_API_BASE_URL: "https://openrouter.ai/api/v1",
 	HEADER_APP_TITLE: `${name} v${version}`,
 	HEADER_APP_URL: homepage,

--- a/src/app/locales/ru.locale.ts
+++ b/src/app/locales/ru.locale.ts
@@ -80,9 +80,13 @@ export const ruLocale: LocaleDefinition = {
 - ALWAYS translate 'deprecated' and related terms (deprecation, deprecating, deprecates) to 'устаревший', 'устаревшее', 'устаревшая' or appropriate forms in ALL contexts (documentation text, comments, headings, lists, etc.)
 	- Exception: Do NOT translate 'deprecated' in HTML comment IDs like {/*deprecated-something*/} - keep these exactly as-is
 	- Exception: Do NOT translate 'deprecated' in URLs, anchor links, or code variable names
-- When a MDN document is referenced, update the language slug to the Russian version ('https://developer.mozilla.org/<slug>/*' => 'https://developer.mozilla.org/ru/*')
+- When a MDN document is referenced, update the language slug to the Russian version for that specific page ('https://developer.mozilla.org/en-US/docs/...' => 'https://developer.mozilla.org/ru/docs/...'), including built-in type references such as String, Array, Map, Set, Date, and Promise
 - Use formal "вы" (not informal "ты") when addressing the reader
-- Preserve English technical terms that are commonly used untranslated in Russian developer communities (e.g., "render", "props", "state", "hook")`,
+- Preserve English technical terms that are commonly used untranslated in Russian developer communities (e.g., "render", "props", "state", "hook")
+- ALWAYS use the letter 'ё' where standard Russian spelling requires it (e.g. 'определён', 'объём', 'жёлтый', 'начнёт'), not the substitute 'е'
+- ALWAYS use Russian guillemets («») for quotation marks, never straight double quotes (")
+- Translate 'bundler' as 'бандлер', not 'сборщик'
+- Use lowercase for 'серверные компоненты' (Server Components) and 'клиентские компоненты' (Client Components), consistent with other compound terms like 'дочерний компонент' and 'классовый компонент'; do not capitalize each word or use 'Компонент Сервера' / 'Компонент Клиента'`,
 	},
 	pullRequest: {
 		title: (file: TranslationFile) => `Перевод \`${file.filename}\` на русский язык`,

--- a/src/app/services/openrouter/openrouter-model-limits.service.ts
+++ b/src/app/services/openrouter/openrouter-model-limits.service.ts
@@ -65,7 +65,7 @@ export class OpenRouterModelLimitsService {
 	 *
 	 * @param baseUrl Same `LLM_API_BASE_URL` used for chat completions
 	 * @param apiKey Bearer token (`LLM_API_KEY`)
-	 * @param modelId Model id to match (for example `google/gemini-2.0-flash-exp:free`)
+	 * @param modelId Model id to match (for example `openai/gpt-oss-20b:free`)
 	 *
 	 * @returns Limits when a matching row is found and numeric fields are usable; otherwise `null`
 	 */

--- a/src/app/utils/translation-cli.util.ts
+++ b/src/app/utils/translation-cli.util.ts
@@ -2,8 +2,6 @@ import { parseArgs } from "citty";
 
 import type { ArgsDef } from "citty";
 
-import { validateEnv } from "../schemas/env.schema";
-
 /** CLI flags that override per-locale matrix values before env validation */
 export const translationCliArgs = {
 	"lang": {
@@ -42,7 +40,7 @@ const translationCliEnvKeys: Record<keyof typeof translationCliArgs, string> = {
 	"translation-guidelines-file": "TRANSLATION_GUIDELINES_FILE",
 };
 /**
- * Applies translation workflow CLI flags to `import.meta.env` before {@link validateEnv} runs.
+ * Applies translation workflow CLI flags to `import.meta.env` before runtime env validation runs.
  *
  * Only non-empty flag values are written. Repository secrets and GitHub Environment variables
  * should stay in the process environment; matrix-specific repo coordinates belong on the CLI.

--- a/src/ci/actions/smoke.ts
+++ b/src/ci/actions/smoke.ts
@@ -1,13 +1,19 @@
 /**
  * CLI entry for real-LLM workflow smoke (`bun run ci:smoke`).
  *
- * Invoked locally or by [`.github/workflows/smoke.yml`](../../.github/workflows/smoke.yml).
- * Reviewable outputs are written under `.out/`. See {@link runWorkflowSmoke} and
+ * Invoked locally or by [`.github/workflows/smoke.yml`](../../.github/workflows/smoke.yml) and the
+ * per-locale gate in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml). Reviewable outputs
+ * are written under `.out/`. See {@link runWorkflowSmoke} and
  * [CONTRIBUTING.md](../../../CONTRIBUTING.md#workflow-smoke) for layout and CI artifacts.
+ *
+ * `TARGET_LANGUAGE` defaults to `pt-br`; pass `--lang`/`-l` (handled by
+ * `bootstrap-cli-overrides.util`, shared with the main translation CLI) to smoke a different
+ * configured locale.
  *
  * @example
  * ```bash
  * bun run ci:smoke -- --profile quick
+ * bun run ci:smoke -- --profile quick --lang ru
  * bun run ci:smoke -- --profile workflow
  * bun run ci:smoke -- --profile full
  * bun run ci:smoke -- --files hydrateRoot.md,lazy.md

--- a/src/ci/actions/smoke.ts
+++ b/src/ci/actions/smoke.ts
@@ -2,7 +2,8 @@
  * CLI entry for real-LLM workflow smoke (`bun run ci:smoke`).
  *
  * Invoked locally or by [`.github/workflows/smoke.yml`](../../.github/workflows/smoke.yml) and the
- * per-locale gate in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml). Reviewable outputs
+ * `pt-br` required gate (plus optional extra locales) in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml).
+ * Reviewable outputs
  * are written under `.out/`. See {@link runWorkflowSmoke} and
  * [CONTRIBUTING.md](../../../CONTRIBUTING.md#workflow-smoke) for layout and CI artifacts.
  *

--- a/src/ci/services/smoke/runner.ts
+++ b/src/ci/services/smoke/runner.ts
@@ -66,6 +66,9 @@ async function clearSmokeArtifactDir(artifactDir: string) {
  * layout and GitHub Actions artifact packaging are documented in
  * [CONTRIBUTING.md](../../../../CONTRIBUTING.md).
  *
+ * The target locale comes from `env.TARGET_LANGUAGE` (default `pt-br`), which the `ci:smoke` CLI's
+ * `--lang` flag overrides before this function runs; see [`smoke.ts`](../../actions/smoke.ts).
+ *
  * @param options Profile, optional fixture override, and output directory
  *
  * @returns Workflow statistics from the runner


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds merge-blocking CI jobs that call live LLMs and secrets (cost, flakiness, 120‑min runs); translator/locale rule changes affect generated PR quality but not auth or data paths.
> 
> **Overview**
> **Release `0.2.10`** bumps the package version and changelog, and switches documented/default LLM placeholders to `openai/gpt-oss-20b:free`.
> 
> **CI** adds a path-based smoke gate when `translator/`, `runner/`, or `locales/` change: required `quick` smoke for **pt-br** (120‑minute job cap, failure artifacts), plus optional matrix smokes for other locales from `.github/locales.json`. A new **`run-workflow-smoke`** composite action centralizes Bun setup, env wiring (`TARGET_LANGUAGE` from `lang`), and `ci:smoke --profile … [--lang …]`; **`smoke.yml`** now calls that action instead of inlining the run step.
> 
> **Runtime/docs**: `ci:smoke` / workflow smoke document **`--lang`** for non-default locales; **`translation-cli.util`** no longer pulls env validation at import time so CLI overrides apply before validation. **`ru.locale.ts`** gains explicit LLM rules (ё, «», бандлер, Server/Client component casing, MDN built-in type URLs). **CONTRIBUTING** describes the new required vs optional CI smoke behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74e86aee660848c4cc20984184ee0509ca73069b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->