### PR TITLE
release `0.2.11`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
   smoke:
     name: Workflow smoke (pt-br)
     needs: detect-smoke-gate
-    if: needs.detect-smoke-gate.outputs.should_run == 'true'
+    if: needs.detect-smoke-gate.outputs.should_run == 'true' && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment: development
@@ -154,7 +154,7 @@ jobs:
   smoke-extra-locales:
     name: Workflow smoke (${{ matrix.lang }}, optional)
     needs: detect-smoke-gate
-    if: needs.detect-smoke-gate.outputs.should_run == 'true' && needs.detect-smoke-gate.outputs.optional_langs != '[]'
+    if: needs.detect-smoke-gate.outputs.should_run == 'true' && needs.detect-smoke-gate.outputs.optional_langs != '[]' && github.event_name == 'pull_request'
     continue-on-error: true
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,4 +1,4 @@
-name: Workflow smoke
+name: Smoke
 
 on:
   workflow_dispatch:
@@ -21,6 +21,14 @@ on:
           - development
           - production
         default: development
+      lang:
+        description: Target locale for smoke run (from .github/locales.json)
+        required: false
+        type: choice
+        options:
+          - pt-br
+          - ru
+        default: pt-br
 
 permissions:
   contents: read
@@ -30,12 +38,12 @@ concurrency:
 
 jobs:
   smoke:
-    name: Real LLM workflow smoke (${{ inputs.profile }})
+    name: Real LLM workflow smoke (${{ inputs.profile }}, ${{ inputs.lang }})
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     env:
       SMOKE_OUTPUT_DIR: .out
-      SMOKE_ARCHIVE_PATH: artifacts/smoke/${{ inputs.profile }}-${{ github.run_id }}.tar.gz
+      SMOKE_ARCHIVE_PATH: artifacts/smoke/${{ inputs.lang }}-${{ inputs.profile }}-${{ github.run_id }}.tar.gz
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -46,6 +54,8 @@ jobs:
         uses: ./.github/actions/run-workflow-smoke
         with:
           profile: ${{ inputs.profile }}
+          lang: ${{ inputs.lang }}
+          target-language: ${{ inputs.lang }}
           bun-version: ${{ vars.BUN_VERSION || '1.3.14' }}
           gh-token: ${{ secrets.GH_TOKEN }}
           llm-api-key: ${{ secrets.LLM_API_KEY }}
@@ -60,7 +70,6 @@ jobs:
           gh-pat-token: ${{ secrets.GH_PAT_TOKEN }}
           max-tokens: ${{ vars.MAX_TOKENS }}
           batch-size: ${{ vars.BATCH_SIZE }}
-          target-language: ${{ vars.TARGET_LANGUAGE }}
           header-app-url: ${{ vars.HEADER_APP_URL }}
           header-app-title: ${{ vars.HEADER_APP_TITLE }}
 
@@ -76,7 +85,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: smoke-${{ inputs.profile }}-${{ github.run_id }}
+          name: smoke-${{ inputs.lang }}-${{ inputs.profile }}-${{ github.run_id }}
           path: ${{ env.SMOKE_ARCHIVE_PATH }}
           archive: false
           if-no-files-found: warn

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -131,24 +131,7 @@ jobs:
 
       - name: Resolve translation targets
         id: translation-target
-        run: |
-          FILE_PATH_INPUT="${{ inputs.file_path }}"
-          FILE_PATH_INPUT="${FILE_PATH_INPUT#"${FILE_PATH_INPUT%%[![:space:]]*}"}"
-          FILE_PATH_INPUT="${FILE_PATH_INPUT%"${FILE_PATH_INPUT##*[![:space:]]}"}"
-
-          TARGET_COUNT="$(bun -e "
-            import { parseTranslationFilePaths } from './src/app/utils/translation-target.util.ts';
-            const fromInput = parseTranslationFilePaths(process.argv[1]);
-            const fromEnv = parseTranslationFilePaths(process.env.TRANSLATION_FILE_PATHS);
-            console.log([...new Set([...fromInput, ...fromEnv])].length);
-          " "$FILE_PATH_INPUT")"
-
-          echo "path=$FILE_PATH_INPUT" >> "$GITHUB_OUTPUT"
-          if [ "$TARGET_COUNT" -gt 0 ]; then
-            echo "has_target_paths=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_target_paths=false" >> "$GITHUB_OUTPUT"
-          fi
+        run: bun run ci:resolve-translation-targets -- --file-path "${{ inputs.file_path }}"
 
       - name: Run translation workflow (${{ matrix.lang }})
         env:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -129,13 +129,26 @@ jobs:
         with:
           bun-version: ${{ vars.BUN_VERSION || '1.3.14' }}
 
-      - name: Resolve translation file path
-        id: translation-file-path
+      - name: Resolve translation targets
+        id: translation-target
         run: |
-          FILE_PATH="${{ inputs.file_path }}"
-          FILE_PATH="${FILE_PATH#"${FILE_PATH%%[![:space:]]*}"}"
-          FILE_PATH="${FILE_PATH%"${FILE_PATH##*[![:space:]]}"}"
-          echo "path=$FILE_PATH" >> "$GITHUB_OUTPUT"
+          FILE_PATH_INPUT="${{ inputs.file_path }}"
+          FILE_PATH_INPUT="${FILE_PATH_INPUT#"${FILE_PATH_INPUT%%[![:space:]]*}"}"
+          FILE_PATH_INPUT="${FILE_PATH_INPUT%"${FILE_PATH_INPUT##*[![:space:]]}"}"
+
+          TARGET_COUNT="$(bun -e "
+            import { parseTranslationFilePaths } from './src/app/utils/translation-target.util.ts';
+            const fromInput = parseTranslationFilePaths(process.argv[1]);
+            const fromEnv = parseTranslationFilePaths(process.env.TRANSLATION_FILE_PATHS);
+            console.log([...new Set([...fromInput, ...fromEnv])].length);
+          " "$FILE_PATH_INPUT")"
+
+          echo "path=$FILE_PATH_INPUT" >> "$GITHUB_OUTPUT"
+          if [ "$TARGET_COUNT" -gt 0 ]; then
+            echo "has_target_paths=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_target_paths=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Run translation workflow (${{ matrix.lang }})
         env:
@@ -173,13 +186,13 @@ jobs:
           if [ -n "${{ matrix.translation_guidelines_file }}" ]; then
             ARGS+=(--translation-guidelines-file "${{ matrix.translation_guidelines_file }}")
           fi
-          if [ -n "${{ steps.translation-file-path.outputs.path }}" ]; then
-            ARGS+=(--file "${{ steps.translation-file-path.outputs.path }}")
+          if [ -n "${{ steps.translation-target.outputs.path }}" ]; then
+            ARGS+=(--file "${{ steps.translation-target.outputs.path }}")
           fi
           bun run start -- "${ARGS[@]}"
 
       - name: Record upstream SHA (${{ matrix.lang }})
-        if: success() && (github.event_name == 'workflow_call' || steps.translation-file-path.outputs.path == '')
+        if: success() && steps.translation-target.outputs.has_target_paths != 'true'
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: string
         default: ""
+      file_path:
+        description: Optional repository path for targeted re-translation (preserves open PR)
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -160,10 +165,13 @@ jobs:
           if [ -n "${{ matrix.translation_guidelines_file }}" ]; then
             ARGS+=(--translation-guidelines-file "${{ matrix.translation_guidelines_file }}")
           fi
+          if [ -n "${{ inputs.file_path }}" ]; then
+            ARGS+=(--file "${{ inputs.file_path }}")
+          fi
           bun run start -- "${ARGS[@]}"
 
       - name: Record upstream SHA (${{ matrix.lang }})
-        if: success()
+        if: success() && (github.event_name == 'workflow_call' || inputs.file_path == '')
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -129,6 +129,14 @@ jobs:
         with:
           bun-version: ${{ vars.BUN_VERSION || '1.3.14' }}
 
+      - name: Resolve translation file path
+        id: translation-file-path
+        run: |
+          FILE_PATH="${{ inputs.file_path }}"
+          FILE_PATH="${FILE_PATH#"${FILE_PATH%%[![:space:]]*}"}"
+          FILE_PATH="${FILE_PATH%"${FILE_PATH##*[![:space:]]}"}"
+          echo "path=$FILE_PATH" >> "$GITHUB_OUTPUT"
+
       - name: Run translation workflow (${{ matrix.lang }})
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
@@ -165,13 +173,13 @@ jobs:
           if [ -n "${{ matrix.translation_guidelines_file }}" ]; then
             ARGS+=(--translation-guidelines-file "${{ matrix.translation_guidelines_file }}")
           fi
-          if [ -n "${{ inputs.file_path }}" ]; then
-            ARGS+=(--file "${{ inputs.file_path }}")
+          if [ -n "${{ steps.translation-file-path.outputs.path }}" ]; then
+            ARGS+=(--file "${{ steps.translation-file-path.outputs.path }}")
           fi
           bun run start -- "${ARGS[@]}"
 
       - name: Record upstream SHA (${{ matrix.lang }})
-        if: success() && (github.event_name == 'workflow_call' || inputs.file_path == '')
+        if: success() && (github.event_name == 'workflow_call' || steps.translation-file-path.outputs.path == '')
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Added
 
+- Targeted file re-translation: pass `--file` / `-f` locally, set `TRANSLATION_FILE_PATHS`, or use workflow `file_path` on manual dispatch to limit a run to specific `src/**/*.md` paths and refresh an open translation pull request in place instead of skipping it.
 - Manual `smoke.yml` dispatch accepts an optional `lang` input (default `pt-br`) to run real-LLM workflow smoke for a chosen configured locale.
 
 ### Changed
 
+- Manual targeted workflow runs skip recording the upstream locale SHA so a single-file refresh does not advance the poll baseline.
 - CI real-LLM smoke runs only on pull requests, not on pushes to `main` or `dev`, so post-merge workflow failures no longer block the default branch when translator changes land without a fresh PR gate.
 
 ## [0.2.10] - 2026-07-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ## [Unreleased]
 
+### Added
+
+- Manual `smoke.yml` dispatch accepts an optional `lang` input (default `pt-br`) to run real-LLM workflow smoke for a chosen configured locale.
+
+### Changed
+
+- CI real-LLM smoke runs only on pull requests, not on pushes to `main` or `dev`, so post-merge workflow failures no longer block the default branch when translator changes land without a fresh PR gate.
+
 ## [0.2.10] - 2026-07-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ## [Unreleased]
 
+## [0.2.11] - 2026-07-06
+
 ### Added
 
 - Targeted file re-translation: pass `--file` / `-f` locally, set `TRANSLATION_FILE_PATHS`, or use workflow `file_path` on manual dispatch to limit a run to specific `src/**/*.md` paths and refresh an open translation pull request in place instead of skipping it.
@@ -333,6 +335,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 - README `MAX_RETRY_ATTEMPTS` default matches runtime (`3`).
 
+[0.2.11]: https://github.com/NivaldoFarias/translate-react/releases/tag/v0.2.11
 [0.2.10]: https://github.com/NivaldoFarias/translate-react/releases/tag/v0.2.10
 [0.2.9]: https://github.com/NivaldoFarias/translate-react/releases/tag/v0.2.9
 [0.2.8]: https://github.com/NivaldoFarias/translate-react/releases/tag/v0.2.8

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "translate-react",
-	"version": "0.2.10",
+	"version": "0.2.11",
 	"contributors": [
 		{
 			"name": "Nivaldo Farias",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"test": "bun test",
 		"ci:poll-upstream": "bun src/ci/actions/poll-upstream.ts",
 		"ci:resolve-matrix": "bun src/ci/actions/resolve-matrix.ts",
+		"ci:resolve-translation-targets": "bun src/ci/actions/resolve-translation-targets.ts",
 		"ci:verify-changelog": "bun src/ci/actions/verify-changelog.ts",
 		"ci:smoke": "bun src/ci/actions/smoke.ts",
 		"ci:changelog-notes": "bun src/ci/actions/changelog-notes.ts",

--- a/src/app/constants/environment.constants.ts
+++ b/src/app/constants/environment.constants.ts
@@ -42,6 +42,9 @@ export interface EnvironmentSchemaDefaults {
 
 	/** Minimum estimated tokens (tiktoken) for a fence to be masked when `MASK_VERBATIM_LARGE_FENCES` is on */
 	MASK_VERBATIM_LARGE_FENCES_MIN_TOKENS: number;
+
+	/** Comma-separated repository paths for targeted re-translation (`--file` / workflow `file_path`) */
+	TRANSLATION_FILE_PATHS?: string;
 }
 
 /**

--- a/src/app/schemas/env.schema.ts
+++ b/src/app/schemas/env.schema.ts
@@ -154,6 +154,16 @@ const envSchema = z.object({
 	TRANSLATION_GUIDELINES_FILE: z.string().optional(),
 
 	/**
+	 * Optional comma-separated repository paths for targeted re-translation.
+	 *
+	 * When set, discovery limits processing to these paths and bypasses valid-pull-request
+	 * skip logic so an open translation PR can be refreshed in place.
+	 *
+	 * @example "src/content/reference/rsc/use-client.md"
+	 */
+	TRANSLATION_FILE_PATHS: z.string().optional(),
+
+	/**
 	 * When enabled, fences at or above `MASK_VERBATIM_LARGE_FENCES_MIN_TOKENS` become HTML
 	 * placeholders before the LLM and are restored after. Prose inside those fences is not
 	 * translated while masked.

--- a/src/app/services/runner/workflow/file-discovery.manager.ts
+++ b/src/app/services/runner/workflow/file-discovery.manager.ts
@@ -14,7 +14,12 @@ import { withRetry } from "@/app/clients/";
 import { DEFAULT_RETRY_CONFIG } from "@/app/clients/octokit/octokit.constants";
 import { FAIL_OPEN_REASONS } from "@/app/constants/fail-open.constants";
 import { TranslationFile } from "@/app/services/translator/";
-import { logger } from "@/app/utils/";
+import {
+	filterToTranslationTargets,
+	getConfiguredTranslationTargetPaths,
+	isConfiguredForceRetranslatePath,
+	logger,
+} from "@/app/utils/";
 import { toSafeErrorLogFields } from "@/shared/errors/error.helpers";
 
 import { TranslationPullRequestValidityManager } from "./translation-pull-request-validity.manager";
@@ -97,18 +102,28 @@ export class FileDiscoveryManager {
 		this.logger.debug({ fileCount: repositoryTree.length }, "Starting file discovery pipeline");
 
 		const failOpenInventory = createEmptyFailOpenInventory();
+		const targetPaths = getConfiguredTranslationTargetPaths();
 
 		const uniqueFiles = repositoryTree.filter(
 			(file, index, self) => index === self.findIndex((compare) => compare.path === file.path),
 		);
+		const scopedFiles = filterToTranslationTargets(uniqueFiles, targetPaths);
+
+		if (targetPaths.length > 0) {
+			this.logger.info(
+				{ targetPaths, matchedFiles: scopedFiles.length },
+				"Restricting discovery to configured translation file paths",
+			);
+		}
+
 		this.logger.debug(
-			{ before: repositoryTree.length, after: uniqueFiles.length },
-			"Stage 1/5: Deduplication complete",
+			{ before: repositoryTree.length, after: scopedFiles.length },
+			"Stage 1/5: Deduplication and target-path filter complete",
 		);
 
-		const { candidateFiles, cacheHits, cacheMisses } = this.checkCache(uniqueFiles);
+		const { candidateFiles, cacheHits, cacheMisses } = this.checkCache(scopedFiles);
 		this.logger.debug(
-			{ before: uniqueFiles.length, after: candidateFiles.length, cacheHits, cacheMisses },
+			{ before: scopedFiles.length, after: candidateFiles.length, cacheHits, cacheMisses },
 			"Stage 2/5: Cache lookup complete",
 		);
 
@@ -152,7 +167,7 @@ export class FileDiscoveryManager {
 			{
 				pipeline: {
 					initial: repositoryTree.length,
-					afterDedup: uniqueFiles.length,
+					afterDedup: scopedFiles.length,
 					afterCache: candidateFiles.length,
 					afterPRFilter: filesToFetch.length,
 					afterContentFetch: uncheckedFiles.length,
@@ -235,6 +250,12 @@ export class FileDiscoveryManager {
 			const cache = languageCaches.get(cacheKey);
 
 			if (cache?.detectedLanguage === targetLanguage && cache.confidence > MIN_CACHE_CONFIDENCE) {
+				if (isConfiguredForceRetranslatePath(file.path)) {
+					cacheMisses++;
+					candidateFiles.push(file);
+					continue;
+				}
+
 				cacheHits++;
 				continue;
 			}
@@ -275,7 +296,7 @@ export class FileDiscoveryManager {
 					DEFAULT_RETRY_CONFIG,
 				);
 
-				if (validity.isValid) {
+				if (validity.isValid && !isConfiguredForceRetranslatePath(file.path)) {
 					numFilesWithPRs++;
 
 					this.logger.debug(
@@ -288,6 +309,21 @@ export class FileDiscoveryManager {
 					);
 
 					continue;
+				}
+
+				if (
+					validity.isValid &&
+					isConfiguredForceRetranslatePath(file.path) &&
+					validity.pullRequest
+				) {
+					this.logger.debug(
+						{
+							path: file.path,
+							prNumber: validity.pullRequest.number,
+							mergeableState: validity.pullRequestStatus?.mergeableState,
+						},
+						"Force re-translating file with valid existing pull request",
+					);
 				}
 
 				if (

--- a/src/app/services/runner/workflow/translation-branch.lifecycle.manager.ts
+++ b/src/app/services/runner/workflow/translation-branch.lifecycle.manager.ts
@@ -5,7 +5,12 @@ import type { RunnerServiceDependencies } from "../runner.types";
 import type { TranslationPullRequestValidity } from "./translation-pull-request-validity.manager";
 
 import { TranslationFile } from "@/app/services/translator/";
-import { getTranslationBranchNameFromPath, logger } from "@/app/utils/";
+import {
+	getTranslationBranchNameFromPath,
+	isConfiguredForceRetranslatePath,
+	logger,
+	shouldPreserveOpenPullRequestOnRefresh,
+} from "@/app/utils/";
 
 import { hasQualifyingApprovedReview } from "./pull-request-review.util";
 
@@ -35,13 +40,14 @@ export class TranslationBranchLifecycleManager {
 	) {
 		const branchName = getTranslationBranchNameFromPath(file.path);
 
-		if (validity.pullRequest && validity.invalidReason === "out_of_sync") {
+		if (shouldPreserveOpenPullRequestOnRefresh(file.path, validity)) {
 			this.logger.info(
 				{
 					filename: file.filename,
-					prNumber: validity.pullRequest.number,
+					prNumber: validity.pullRequest?.number,
 					branchName,
-					invalidReason: validity.invalidReason,
+					invalidReason: validity.invalidReason ?? null,
+					forceRetranslate: isConfiguredForceRetranslatePath(file.path),
 				},
 				"Refreshing translation branch from fork default while preserving open pull request",
 			);

--- a/src/app/services/runner/workflow/translation-file.processor.ts
+++ b/src/app/services/runner/workflow/translation-file.processor.ts
@@ -11,6 +11,7 @@ import { PullRequestProgressAction } from "@/app/services/github/types";
 import { TranslationFile } from "@/app/services/translator/";
 import {
 	getTranslationBranchNameFromPath,
+	isConfiguredForceRetranslatePath,
 	isTranslationEquivalentToCurrentBlob,
 	logger,
 } from "@/app/utils/";
@@ -245,6 +246,10 @@ export class TranslationFileProcessor {
 		batchProgress: TranslationBatchProgressCallbacks,
 	) {
 		if (!validity.isValid || !validity.pullRequest) {
+			return null;
+		}
+
+		if (isConfiguredForceRetranslatePath(file.path)) {
 			return null;
 		}
 

--- a/src/app/services/runner/workflow/translation-pull-request.lifecycle.manager.ts
+++ b/src/app/services/runner/workflow/translation-pull-request.lifecycle.manager.ts
@@ -9,7 +9,12 @@ import type { TranslationPullRequestValidity } from "./translation-pull-request-
 
 import { PullRequestProgressAction } from "@/app/services/github/types";
 import { TranslationFile } from "@/app/services/translator/";
-import { env, getTranslationBranchNameFromPath, logger } from "@/app/utils/";
+import {
+	env,
+	getTranslationBranchNameFromPath,
+	logger,
+	shouldPreserveOpenPullRequestOnRefresh,
+} from "@/app/utils/";
 
 /**
  * Returns the hostname of the configured LLM API base URL for PR metadata.
@@ -60,25 +65,26 @@ export class TranslationPullRequestLifecycleManager {
 		pullRequest: NonNullable<ProcessedFileResult["pullRequest"]>;
 		progress: PullRequestProgressAction;
 	}> {
-		if (validity.pullRequest && validity.invalidReason === "out_of_sync") {
+		if (shouldPreserveOpenPullRequestOnRefresh(file.path, validity) && validity.pullRequest) {
+			const openPullRequest = validity.pullRequest;
 			const languageName = this.services.languageDetector.getLanguageName(
 				this.services.languageDetector.languages.target,
 			);
 			const body = this.createPullRequestDescription(file, processingResult, languageName);
 
-			await this.services.github.updatePullRequestBody(validity.pullRequest.number, body);
+			await this.services.github.updatePullRequestBody(openPullRequest.number, body);
 
 			this.logger.info(
 				{
 					path: file.path,
-					prNumber: validity.pullRequest.number,
+					prNumber: openPullRequest.number,
 					advisoryGuardCount: processingResult.reviewerNotices.length,
 				},
 				"Refreshed open translation pull request after upstream sync",
 			);
 
 			return {
-				pullRequest: validity.pullRequest,
+				pullRequest: openPullRequest,
 				progress: PullRequestProgressAction.Reused,
 			};
 		}

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -9,3 +9,4 @@ export * from "./logger.util";
 export * from "./markdown-verbatim-fences.util";
 export * from "./openrouter-run-user.util";
 export * from "./translation-content-compare.util";
+export * from "./translation-target.util";

--- a/src/app/utils/parse-translation-file-paths.util.ts
+++ b/src/app/utils/parse-translation-file-paths.util.ts
@@ -1,0 +1,53 @@
+/**
+ * Parses comma-separated repository paths from CLI or environment input.
+ *
+ * @param raw Comma-separated paths or `undefined` when unset
+ *
+ * @returns Deduplicated, trimmed paths in input order
+ */
+export function parseTranslationFilePaths(raw: string | undefined) {
+	if (!raw?.trim()) {
+		return [];
+	}
+
+	const seen = new Set<string>();
+	const paths: string[] = [];
+
+	for (const segment of raw.split(",")) {
+		const path = segment.trim();
+
+		if (!path || seen.has(path)) {
+			continue;
+		}
+
+		seen.add(path);
+		paths.push(path);
+	}
+
+	return paths;
+}
+
+/**
+ * Merges translation path sources into one deduplicated list.
+ *
+ * @param sources Raw comma-separated path strings from CLI flags or environment
+ *
+ * @returns Combined paths in first-seen order
+ */
+export function collectTranslationFilePaths(...sources: (string | undefined)[]) {
+	const paths: string[] = [];
+	const seen = new Set<string>();
+
+	for (const source of sources) {
+		for (const path of parseTranslationFilePaths(source)) {
+			if (seen.has(path)) {
+				continue;
+			}
+
+			seen.add(path);
+			paths.push(path);
+		}
+	}
+
+	return paths;
+}

--- a/src/app/utils/translation-cli.util.ts
+++ b/src/app/utils/translation-cli.util.ts
@@ -2,7 +2,7 @@ import { parseArgs } from "citty";
 
 import type { ArgsDef } from "citty";
 
-import { parseTranslationFilePaths } from "./translation-target.util";
+import { parseTranslationFilePaths } from "./parse-translation-file-paths.util";
 
 /** CLI flags that override per-locale matrix values before env validation */
 export const translationCliArgs = {

--- a/src/app/utils/translation-cli.util.ts
+++ b/src/app/utils/translation-cli.util.ts
@@ -2,6 +2,8 @@ import { parseArgs } from "citty";
 
 import type { ArgsDef } from "citty";
 
+import { parseTranslationFilePaths } from "./translation-target.util";
+
 /** CLI flags that override per-locale matrix values before env validation */
 export const translationCliArgs = {
 	"lang": {
@@ -29,16 +31,51 @@ export const translationCliArgs = {
 		type: "string",
 		description: "Upstream guidelines filename (`TRANSLATION_GUIDELINES_FILE`)",
 	},
+	"file": {
+		type: "string",
+		description:
+			"Repository path to re-translate (`TRANSLATION_FILE_PATHS`); comma-separated or repeat the flag",
+		alias: "f",
+	},
 } satisfies ArgsDef;
 
-const translationCliEnvKeys: Record<keyof typeof translationCliArgs, string> = {
+const translationCliEnvKeys = {
 	"lang": "TARGET_LANGUAGE",
 	"fork-owner": "REPO_FORK_OWNER",
 	"fork-name": "REPO_FORK_NAME",
 	"upstream-owner": "REPO_UPSTREAM_OWNER",
 	"upstream-name": "REPO_UPSTREAM_NAME",
 	"translation-guidelines-file": "TRANSLATION_GUIDELINES_FILE",
-};
+} satisfies Record<Exclude<keyof typeof translationCliArgs, "file">, string>;
+
+/**
+ * Collects repeated `--file` / `-f` flags from raw argv before citty parsing.
+ *
+ * @param rawArgs Arguments after the script path
+ *
+ * @returns Deduplicated repository paths in argv order
+ */
+function collectRepeatedTranslationFilePaths(rawArgs: string[]) {
+	const paths: string[] = [];
+
+	for (let index = 0; index < rawArgs.length; index++) {
+		const arg = rawArgs[index];
+
+		if (arg !== "--file" && arg !== "-f") {
+			continue;
+		}
+
+		const value = rawArgs[index + 1];
+
+		if (!value || value.startsWith("-")) {
+			continue;
+		}
+
+		paths.push(...parseTranslationFilePaths(value));
+	}
+
+	return paths;
+}
 /**
  * Applies translation workflow CLI flags to `import.meta.env` before runtime env validation runs.
  *
@@ -67,5 +104,15 @@ export function applyTranslationCliOverrides(rawArgs: string[]) {
 		}
 
 		import.meta.env[envKey] = value;
+	}
+
+	const filePaths = [
+		...collectRepeatedTranslationFilePaths(rawArgs),
+		...parseTranslationFilePaths(typeof parsed["file"] === "string" ? parsed["file"] : undefined),
+	];
+	const uniqueFilePaths = [...new Set(filePaths)];
+
+	if (uniqueFilePaths.length > 0) {
+		import.meta.env["TRANSLATION_FILE_PATHS"] = uniqueFilePaths.join(",");
 	}
 }

--- a/src/app/utils/translation-target.util.ts
+++ b/src/app/utils/translation-target.util.ts
@@ -3,35 +3,9 @@ import type { TranslationPullRequestValidity } from "@/app/services/runner/workf
 import { env } from "@/app/schemas/env.schema";
 
 import { isSafeTranslatablePath } from "./markdown-path.util";
+import { parseTranslationFilePaths } from "./parse-translation-file-paths.util";
 
-/**
- * Parses comma-separated repository paths from CLI or environment input.
- *
- * @param raw Comma-separated paths or `undefined` when unset
- *
- * @returns Deduplicated, trimmed paths in input order
- */
-export function parseTranslationFilePaths(raw: string | undefined) {
-	if (!raw?.trim()) {
-		return [];
-	}
-
-	const seen = new Set<string>();
-	const paths: string[] = [];
-
-	for (const segment of raw.split(",")) {
-		const path = segment.trim();
-
-		if (!path || seen.has(path)) {
-			continue;
-		}
-
-		seen.add(path);
-		paths.push(path);
-	}
-
-	return paths;
-}
+export { parseTranslationFilePaths } from "./parse-translation-file-paths.util";
 
 /**
  * Returns configured single-file or multi-file translation targets from the environment.

--- a/src/app/utils/translation-target.util.ts
+++ b/src/app/utils/translation-target.util.ts
@@ -1,0 +1,121 @@
+import type { TranslationPullRequestValidity } from "@/app/services/runner/workflow/translation-pull-request-validity.manager";
+
+import { env } from "@/app/schemas/env.schema";
+
+import { isSafeTranslatablePath } from "./markdown-path.util";
+
+/**
+ * Parses comma-separated repository paths from CLI or environment input.
+ *
+ * @param raw Comma-separated paths or `undefined` when unset
+ *
+ * @returns Deduplicated, trimmed paths in input order
+ */
+export function parseTranslationFilePaths(raw: string | undefined) {
+	if (!raw?.trim()) {
+		return [];
+	}
+
+	const seen = new Set<string>();
+	const paths: string[] = [];
+
+	for (const segment of raw.split(",")) {
+		const path = segment.trim();
+
+		if (!path || seen.has(path)) {
+			continue;
+		}
+
+		seen.add(path);
+		paths.push(path);
+	}
+
+	return paths;
+}
+
+/**
+ * Returns configured single-file or multi-file translation targets from the environment.
+ *
+ * @returns Parsed {@link env.TRANSLATION_FILE_PATHS} entries
+ */
+export function getConfiguredTranslationTargetPaths() {
+	return parseTranslationFilePaths(env.TRANSLATION_FILE_PATHS);
+}
+
+/**
+ * Returns whether `filePath` is a configured force-retranslation target.
+ *
+ * @param filePath Repository path under `src/`
+ * @param targetPaths Configured target paths
+ *
+ * @returns `true` when the path is listed for targeted re-translation
+ */
+export function isForceRetranslatePath(filePath: string, targetPaths: readonly string[]) {
+	return targetPaths.length > 0 && targetPaths.includes(filePath);
+}
+
+/**
+ * Returns whether `filePath` should bypass valid-pull-request skip logic.
+ *
+ * @param filePath Repository path under `src/`
+ *
+ * @returns `true` when targeted re-translation is configured for the path
+ */
+export function isConfiguredForceRetranslatePath(filePath: string) {
+	return isForceRetranslatePath(filePath, getConfiguredTranslationTargetPaths());
+}
+
+/**
+ * Returns whether an open translation pull request should be refreshed in place.
+ *
+ * @param filePath Repository path under `src/`
+ * @param validity Pull request validity evaluated at file-processing start
+ * @param targetPaths Configured target paths; defaults to {@link getConfiguredTranslationTargetPaths}
+ *
+ * @returns `true` when the branch should be reset without closing the open PR
+ */
+export function shouldPreserveOpenPullRequestOnRefresh(
+	filePath: string,
+	validity: Pick<TranslationPullRequestValidity, "pullRequest" | "invalidReason">,
+	targetPaths: readonly string[] = getConfiguredTranslationTargetPaths(),
+) {
+	if (!validity.pullRequest) {
+		return false;
+	}
+
+	if (validity.invalidReason === "out_of_sync") {
+		return true;
+	}
+
+	return isForceRetranslatePath(filePath, targetPaths);
+}
+
+/**
+ * Restricts repository tree items to configured translation targets.
+ *
+ * @param files Candidate repository paths
+ * @param targetPaths Configured target paths; empty means no restriction
+ *
+ * @returns Filtered files when targets are configured, otherwise the original list
+ */
+export function filterToTranslationTargets<T extends { path: string }>(
+	files: T[],
+	targetPaths: readonly string[],
+) {
+	if (targetPaths.length === 0) {
+		return files;
+	}
+
+	return files.filter((file) => targetPaths.includes(file.path));
+}
+
+/**
+ * Validates configured translation target paths for safe markdown I/O.
+ *
+ * @param targetPaths Configured target paths
+ *
+ * @returns Paths that fail {@link isSafeTranslatablePath}
+ */
+export function findUnsafeTranslationTargetPaths(targetPaths: readonly string[]) {
+	return targetPaths.filter((path) => !isSafeTranslatablePath(path));
+}

--- a/src/ci/actions/changelog-notes.ts
+++ b/src/ci/actions/changelog-notes.ts
@@ -19,7 +19,7 @@ import { defineCommand, runCommand } from "citty";
 import { extractChangelogEntries } from "@/ci/utils/changelog.util";
 import { createLogger } from "@/shared/utils/create-logger.util";
 
-const log = createLogger({ level: "info", logToConsole: true }).child({
+const logger = createLogger({ level: "info", logToConsole: true }).child({
 	component: "changelog-notes",
 });
 
@@ -58,7 +58,7 @@ const changelogNotesCommand = defineCommand({
 		const entries = extractChangelogEntries(changelog, version);
 
 		if (entries === null || entries.length === 0) {
-			log.error({ version }, "No CHANGELOG.md section found for version");
+			logger.error({ version }, "No CHANGELOG.md section found for version");
 			process.exit(1);
 		}
 
@@ -66,7 +66,7 @@ const changelogNotesCommand = defineCommand({
 
 		writeFileSync(outputPath, `${entries}\n`);
 
-		log.info({ version, outputPath }, "Wrote release notes");
+		logger.info({ version, outputPath }, "Wrote release notes");
 	},
 });
 

--- a/src/ci/actions/poll-upstream.ts
+++ b/src/ci/actions/poll-upstream.ts
@@ -18,7 +18,7 @@ import {
 } from "@/ci/utils/workflow-script.util";
 import { createLogger } from "@/shared/utils/create-logger.util";
 
-const log = createLogger({ level: "info", logToConsole: true }).child({
+const logger = createLogger({ level: "info", logToConsole: true }).child({
 	component: "poll-upstream",
 });
 
@@ -28,7 +28,7 @@ const log = createLogger({ level: "info", logToConsole: true }).child({
 async function main() {
 	const context = resolveCiScriptContext();
 
-	log.debug(
+	logger.debug(
 		{
 			repository: context.repositorySlug,
 			forkOwner: context.forkOwner,
@@ -40,12 +40,12 @@ async function main() {
 	const octokit = createWorkflowScriptOctokit(context);
 	const locales = loadUpstreamLocales();
 
-	const variableReader = new UpstreamShaVariableReader(octokit, context.repository, log);
-	const poller = new UpstreamShaPoller(octokit, variableReader, log);
+	const variableReader = new UpstreamShaVariableReader(octokit, context.repository, logger);
+	const poller = new UpstreamShaPoller(octokit, variableReader, logger);
 
 	const result = await poller.poll(locales, context.forkOwner);
 
-	log.info(
+	logger.info(
 		{
 			hasChanges: result.hasChanges,
 			langs: result.matrix.map((row) => row.lang),
@@ -53,7 +53,7 @@ async function main() {
 		"Upstream poll finished",
 	);
 
-	writePollWorkflowOutputs(log, result.hasChanges, result.matrix);
+	writePollWorkflowOutputs(logger, result.hasChanges, result.matrix);
 }
 
 await main();

--- a/src/ci/actions/prepare-release.ts
+++ b/src/ci/actions/prepare-release.ts
@@ -21,7 +21,7 @@ import { promoteUnreleasedToVersion } from "@/ci/utils/changelog.util";
 import { bumpPackageVersion, readPackageVersion } from "@/ci/utils/release.util";
 import { createLogger } from "@/shared/utils/create-logger.util";
 
-const log = createLogger({ level: "info", logToConsole: true }).child({
+const logger = createLogger({ level: "info", logToConsole: true }).child({
 	component: "prepare-release",
 });
 
@@ -45,7 +45,7 @@ const prepareReleaseCommand = defineCommand({
 
 		const version = readPackageVersion(repositoryRoot);
 
-		log.info({ previousVersion, version }, "Bumped package.json version");
+		logger.info({ previousVersion, version }, "Bumped package.json version");
 
 		const changelogPath = join(repositoryRoot, "CHANGELOG.md");
 		const changelog = readFileSync(changelogPath, "utf8");
@@ -53,7 +53,7 @@ const prepareReleaseCommand = defineCommand({
 
 		writeFileSync(changelogPath, promoted);
 
-		log.info({ version }, "Promoted CHANGELOG.md Unreleased section");
+		logger.info({ version }, "Promoted CHANGELOG.md Unreleased section");
 	},
 });
 

--- a/src/ci/actions/resolve-matrix.ts
+++ b/src/ci/actions/resolve-matrix.ts
@@ -23,7 +23,7 @@ import {
 } from "@/ci/utils/workflow-script.util";
 import { createLogger } from "@/shared/utils/create-logger.util";
 
-const log = createLogger({ level: "info", logToConsole: true }).child({
+const logger = createLogger({ level: "info", logToConsole: true }).child({
 	component: "resolve-matrix",
 });
 
@@ -45,11 +45,11 @@ const resolveMatrixCommand = defineCommand({
 			.map((entry) => entry.trim())
 			.filter((entry) => entry.length > 0);
 
-		log.debug({ langsArgument: args.langs, langs }, "Parsed CLI arguments");
+		logger.debug({ langsArgument: args.langs, langs }, "Parsed CLI arguments");
 
 		const context = resolveCiScriptContext();
 
-		log.debug(
+		logger.debug(
 			{
 				repository: context.repositorySlug,
 				forkOwner: context.forkOwner,
@@ -60,16 +60,16 @@ const resolveMatrixCommand = defineCommand({
 
 		const locales = filterUpstreamLocalesByLang(loadUpstreamLocales(), langs);
 
-		log.debug({ localeCount: locales.length }, "Upstream locales selected for matrix");
+		logger.debug({ localeCount: locales.length }, "Upstream locales selected for matrix");
 
 		const octokit = createWorkflowScriptOctokit(context);
-		const builder = new TranslationMatrixBuilder(octokit, log);
+		const builder = new TranslationMatrixBuilder(octokit, logger);
 
 		const matrix = await builder.build(locales, context.forkOwner);
 
-		log.info({ langs: matrix.map((row) => row.lang) }, "Translation matrix resolved");
+		logger.info({ langs: matrix.map((row) => row.lang) }, "Translation matrix resolved");
 
-		writeResolveMatrixWorkflowOutputs(log, matrix);
+		writeResolveMatrixWorkflowOutputs(logger, matrix);
 	},
 });
 

--- a/src/ci/actions/resolve-translation-targets.ts
+++ b/src/ci/actions/resolve-translation-targets.ts
@@ -1,0 +1,47 @@
+/**
+ * Resolves targeted translation paths for manual workflow dispatch.
+ *
+ * Writes `path` and `has_target_paths` to `GITHUB_OUTPUT` without loading app env validation.
+ *
+ * @example
+ * ```bash
+ * bun run ci:resolve-translation-targets -- --file-path "src/content/blog/post.md"
+ * ```
+ */
+
+import { defineCommand, runCommand } from "citty";
+
+import { writeCiWorkflowOutput } from "@/ci/utils/github-output.util";
+import { resolveTranslationTargets } from "@/ci/utils/resolve-translation-targets.util";
+import { createLogger } from "@/shared/utils/create-logger.util";
+
+const logger = createLogger({ level: "info", logToConsole: true }).child({
+	component: "resolve-translation-targets",
+});
+
+const resolveTranslationTargetsCommand = defineCommand({
+	meta: {
+		name: "resolve-translation-targets",
+		description: "Resolve targeted translation paths for workflow dispatch",
+	},
+	args: {
+		"file-path": {
+			type: "string",
+			description: "Manual workflow file_path input",
+			default: "",
+		},
+	},
+	run({ args }) {
+		const resolved = resolveTranslationTargets({
+			filePathInput: args["file-path"],
+			translationFilePathsEnv: import.meta.env["TRANSLATION_FILE_PATHS"],
+		});
+
+		logger.debug(resolved, "Resolved translation targets");
+
+		writeCiWorkflowOutput("path", resolved.path);
+		writeCiWorkflowOutput("has_target_paths", resolved.hasTargetPaths ? "true" : "false");
+	},
+});
+
+await runCommand(resolveTranslationTargetsCommand, { rawArgs: process.argv.slice(2) });

--- a/src/ci/actions/smoke.ts
+++ b/src/ci/actions/smoke.ts
@@ -29,7 +29,7 @@ import { isSmokeProfileId, run, runSucceeded, SmokeProfile } from "@/ci/services
 import { handleTopLevelError } from "@/shared/errors/";
 import { createLogger } from "@/shared/utils/create-logger.util";
 
-const log = createLogger({ level: "info", logToConsole: true }).child({
+const logger = createLogger({ level: "info", logToConsole: true }).child({
 	component: "smoke",
 });
 
@@ -53,7 +53,7 @@ const smokeCommand = defineCommand({
 	},
 	async run({ args }) {
 		if (!isSmokeProfileId(args.profile)) {
-			log.error(
+			logger.error(
 				{ profile: args.profile, allowed: Object.values(SmokeProfile) },
 				"Invalid smoke profile",
 			);
@@ -67,13 +67,13 @@ const smokeCommand = defineCommand({
 			});
 
 			if (!runSucceeded(stats)) {
-				log.error({ stats }, "Run reported translation failures");
+				logger.error({ stats }, "Run reported translation failures");
 				process.exit(1);
 			}
 
 			process.exit(0);
 		} catch (error) {
-			handleTopLevelError(error, log);
+			handleTopLevelError(error, logger);
 			process.exit(1);
 		}
 	},

--- a/src/ci/actions/smoke.ts
+++ b/src/ci/actions/smoke.ts
@@ -25,12 +25,7 @@ import "@/app/utils/bootstrap-cli-overrides.util";
 
 import { defineCommand, runCommand } from "citty";
 
-import {
-	isSmokeProfileId,
-	runWorkflowSmoke,
-	SmokeProfile,
-	workflowSmokeSucceeded,
-} from "@/ci/services/smoke";
+import { isSmokeProfileId, run, runSucceeded, SmokeProfile } from "@/ci/services/smoke";
 import { handleTopLevelError } from "@/shared/errors/";
 import { createLogger } from "@/shared/utils/create-logger.util";
 
@@ -41,7 +36,7 @@ const log = createLogger({ level: "info", logToConsole: true }).child({
 const smokeCommand = defineCommand({
 	meta: {
 		name: "smoke",
-		description: "Run workflow smoke with real LLM and mocked GitHub fixtures",
+		description: "Run with real LLM and mocked GitHub fixtures",
 	},
 	args: {
 		profile: {
@@ -66,13 +61,13 @@ const smokeCommand = defineCommand({
 		}
 
 		try {
-			const stats = await runWorkflowSmoke({
+			const stats = await run({
 				profile: args.profile,
 				filesArgument: args.files,
 			});
 
-			if (!workflowSmokeSucceeded(stats)) {
-				log.error({ stats }, "Workflow smoke reported translation failures");
+			if (!runSucceeded(stats)) {
+				log.error({ stats }, "Run reported translation failures");
 				process.exit(1);
 			}
 

--- a/src/ci/actions/verify-changelog.ts
+++ b/src/ci/actions/verify-changelog.ts
@@ -12,14 +12,14 @@
 import { verifyChangelogListsPackageVersion } from "@/ci/utils/verify-changelog.util";
 import { createLogger } from "@/shared/utils/create-logger.util";
 
-const log = createLogger({ level: "info", logToConsole: true }).child({
+const logger = createLogger({ level: "info", logToConsole: true }).child({
 	component: "verify-changelog",
 });
 
 try {
 	verifyChangelogListsPackageVersion();
-	log.info("CHANGELOG.md includes the current package version");
+	logger.info("CHANGELOG.md includes the current package version");
 } catch (error) {
-	log.error({ error }, "CHANGELOG version check failed");
+	logger.error({ error }, "CHANGELOG version check failed");
 	process.exit(1);
 }

--- a/src/ci/schemas/env.schema.ts
+++ b/src/ci/schemas/env.schema.ts
@@ -15,8 +15,16 @@ export const ciPollResolveEnvSchema = z.object({
 	GITHUB_REPOSITORY_OWNER: z.string().optional(),
 });
 
+/** Zod schema for workflow scripts that only write `GITHUB_OUTPUT` */
+export const ciWorkflowOutputEnvSchema = z.object({
+	GITHUB_OUTPUT: z.string().min(1),
+});
+
 /** Parsed CI poll/resolve environment */
 export type CiPollResolveEnvironment = z.infer<typeof ciPollResolveEnvSchema>;
+
+/** Parsed CI workflow output environment */
+export type CiWorkflowOutputEnvironment = z.infer<typeof ciWorkflowOutputEnvSchema>;
 
 /**
  * Validates CI poll/resolve environment variables.
@@ -39,6 +47,29 @@ let cachedCiPollResolveEnvironment: CiPollResolveEnvironment | undefined;
 export function getCiPollResolveEnv() {
 	cachedCiPollResolveEnvironment ??= parseCiPollResolveEnvironment();
 	return cachedCiPollResolveEnvironment;
+}
+
+/**
+ * Validates CI workflow output environment variables.
+ *
+ * @param environment Source map (defaults to `import.meta.env`)
+ *
+ * @returns Parsed {@link CiWorkflowOutputEnvironment}
+ */
+export function parseCiWorkflowOutputEnvironment(environment?: Record<string, unknown>) {
+	return ciWorkflowOutputEnvSchema.parse(environment ?? import.meta.env);
+}
+
+let cachedCiWorkflowOutputEnvironment: CiWorkflowOutputEnvironment | undefined;
+
+/**
+ * Returns parsed CI workflow output environment, parsing once per process.
+ *
+ * @returns from `import.meta.env`
+ */
+export function getCiWorkflowOutputEnv() {
+	cachedCiWorkflowOutputEnvironment ??= parseCiWorkflowOutputEnvironment();
+	return cachedCiWorkflowOutputEnvironment;
 }
 
 /** Validated GitHub Actions context for poll/resolve scripts */

--- a/src/ci/services/smoke/runner.ts
+++ b/src/ci/services/smoke/runner.ts
@@ -44,7 +44,7 @@ export interface SmokeRunOptions {
 	artifactDir?: string;
 }
 
-const log = createLogger({ level: "info", logToConsole: true }).child({
+const logger = createLogger({ level: "info", logToConsole: true }).child({
 	component: "smoke-runner",
 });
 
@@ -55,7 +55,7 @@ const log = createLogger({ level: "info", logToConsole: true }).child({
  */
 async function clearSmokeArtifactDir(artifactDir: string) {
 	await fs.rm(artifactDir, { recursive: true, force: true });
-	log.debug({ artifactDir }, "Cleared previous artifacts");
+	logger.debug({ artifactDir }, "Cleared previous artifacts");
 }
 
 /**
@@ -92,12 +92,12 @@ export async function run(options: SmokeRunOptions) {
 
 	await clearSmokeArtifactDir(artifactDir);
 
-	log.debug({ fixtureDir: MD_FIXTURE_DIR, basenames: basenames ?? "all" }, "Loading fixtures");
+	logger.debug({ fixtureDir: MD_FIXTURE_DIR, basenames: basenames ?? "all" }, "Loading fixtures");
 
 	const integrationFiles = await loadWorkflowFilesFromMdFixtureDir(basenames, cwd);
 	const totalBytes = integrationFiles.reduce((sum, file) => sum + file.blob.content.length, 0);
 
-	log.debug(
+	logger.debug(
 		{
 			fixtureDir: MD_FIXTURE_DIR,
 			fileCount: integrationFiles.length,
@@ -122,7 +122,7 @@ export async function run(options: SmokeRunOptions) {
 		{ batchSize: 1 },
 	);
 
-	log.info(
+	logger.info(
 		{
 			model: env.LLM_MODEL,
 			profile: options.profile,
@@ -134,7 +134,7 @@ export async function run(options: SmokeRunOptions) {
 
 	const stats = await runner.run();
 
-	log.info({ stats }, "Run finished");
+	logger.info({ stats }, "Run finished");
 
 	return stats;
 }

--- a/src/ci/services/smoke/runner.ts
+++ b/src/ci/services/smoke/runner.ts
@@ -23,10 +23,10 @@ import {
 import { resolveSmokeFixtureBasenames } from "./smoke-profiles.util";
 
 /** Gitignored directory where `ci:smoke` writes reviewable mocked GitHub outputs. */
-export const WORKFLOW_SMOKE_ARTIFACT_DIR = ".out" as const;
+export const SMOKE_ARTIFACT_DIR = ".out" as const;
 
-/** Options for {@link runWorkflowSmoke} */
-export interface RunWorkflowSmokeOptions {
+/** Options for {@link run} */
+export interface SmokeRunOptions {
 	/**
 	 * {@link SmokeProfileId} fixture set.
 	 *
@@ -40,12 +40,12 @@ export interface RunWorkflowSmokeOptions {
 	/** Repository root for fixture and artifact paths */
 	cwd?: string;
 
-	/** Relative artifact root (defaults to {@link WORKFLOW_SMOKE_ARTIFACT_DIR}) */
+	/** Relative artifact root (defaults to {@link SMOKE_ARTIFACT_DIR}) */
 	artifactDir?: string;
 }
 
 const log = createLogger({ level: "info", logToConsole: true }).child({
-	component: "workflow-smoke",
+	component: "smoke-runner",
 });
 
 /**
@@ -55,14 +55,14 @@ const log = createLogger({ level: "info", logToConsole: true }).child({
  */
 async function clearSmokeArtifactDir(artifactDir: string) {
 	await fs.rm(artifactDir, { recursive: true, force: true });
-	log.debug({ artifactDir }, "Cleared previous workflow smoke artifacts");
+	log.debug({ artifactDir }, "Cleared previous artifacts");
 }
 
 /**
  * Runs {@link RunnerService} with real {@link translatorService} and mocked GitHub fixtures.
  *
  * Loads markdown from `tests/fixtures/md/` and writes translated blobs, PR bodies, and progress
- * comments under {@link WORKFLOW_SMOKE_ARTIFACT_DIR} unless `artifactDir` overrides it. Output
+ * comments under {@link SMOKE_ARTIFACT_DIR} unless `artifactDir` overrides it. Output
  * layout and GitHub Actions artifact packaging are documented in
  * [CONTRIBUTING.md](../../../../CONTRIBUTING.md).
  *
@@ -77,16 +77,16 @@ async function clearSmokeArtifactDir(artifactDir: string) {
  *
  * @example
  * ```typescript
- * const stats = await runWorkflowSmoke({ profile: "quick" });
+ * const stats = await run({ profile: "quick" });
  * ```
  */
-export async function runWorkflowSmoke(options: RunWorkflowSmokeOptions) {
+export async function run(options: SmokeRunOptions) {
 	if (env.NODE_ENV === RuntimeEnvironment.Test) {
-		throw new Error("Workflow smoke must not run under NODE_ENV=test (use bun run ci:smoke)");
+		throw new Error("Run must not run under NODE_ENV=test (use bun run ci:smoke)");
 	}
 
 	const cwd = options.cwd ?? process.cwd();
-	const artifactDirRelative = options.artifactDir ?? WORKFLOW_SMOKE_ARTIFACT_DIR;
+	const artifactDirRelative = options.artifactDir ?? SMOKE_ARTIFACT_DIR;
 	const artifactDir = path.resolve(cwd, artifactDirRelative);
 	const basenames = resolveSmokeFixtureBasenames(options.profile, options.filesArgument ?? "");
 
@@ -103,7 +103,7 @@ export async function runWorkflowSmoke(options: RunWorkflowSmokeOptions) {
 			fileCount: integrationFiles.length,
 			markdownBytes: totalBytes,
 		},
-		"Workflow smoke fixtures loaded",
+		"Fixtures loaded",
 	);
 
 	const github = createWorkflowGitHubServiceFromFiles(integrationFiles, {
@@ -129,12 +129,12 @@ export async function runWorkflowSmoke(options: RunWorkflowSmokeOptions) {
 			artifactDir: artifactDirRelative,
 			files: integrationFiles.map((file) => file.treeItem.path),
 		},
-		"Workflow smoke started",
+		"Run started",
 	);
 
 	const stats = await runner.run();
 
-	log.info({ stats }, "Workflow smoke finished");
+	log.info({ stats }, "Run finished");
 
 	return stats;
 }
@@ -142,11 +142,11 @@ export async function runWorkflowSmoke(options: RunWorkflowSmokeOptions) {
 /**
  * Reports whether every discovered file translated successfully.
  *
- * @param stats Runner result from {@link runWorkflowSmoke}
+ * @param stats Runner result from {@link run}
  *
  * @returns `true` when `successCount` equals `totalCount` and `failureCount` is zero
  */
-export function workflowSmokeSucceeded(stats: WorkflowStatistics) {
+export function runSucceeded(stats: WorkflowStatistics) {
 	return (
 		stats.totalCount > 0 && stats.failureCount === 0 && stats.successCount === stats.totalCount
 	);

--- a/src/ci/utils/github-output.util.ts
+++ b/src/ci/utils/github-output.util.ts
@@ -1,15 +1,16 @@
 import { appendFileSync } from "node:fs";
 
-import { getCiPollResolveEnv } from "@/ci/schemas/env.schema";
+import { getCiPollResolveEnv, getCiWorkflowOutputEnv } from "@/ci/schemas/env.schema";
 import { ApplicationError, ErrorCode } from "@/shared/errors/";
 
 /**
- * Appends a single-line value to the GitHub Actions `GITHUB_OUTPUT` file.
+ * Appends a single-line value to a GitHub Actions output file.
  *
  * @param name Output id consumed by workflow `steps.<id>.outputs.<name>`
  * @param value Scalar output (must not contain raw newlines)
+ * @param githubOutputPath Absolute path to `GITHUB_OUTPUT`
  */
-export function writeGitHubActionsOutput(name: string, value: string) {
+function writeGitHubActionsOutputToPath(name: string, value: string, githubOutputPath: string) {
 	if (value.includes("\n")) {
 		throw new ApplicationError(
 			`GitHub Actions output "${name}" must be a single line`,
@@ -19,5 +20,25 @@ export function writeGitHubActionsOutput(name: string, value: string) {
 		);
 	}
 
-	appendFileSync(getCiPollResolveEnv().GITHUB_OUTPUT, `${name}=${value}\n`);
+	appendFileSync(githubOutputPath, `${name}=${value}\n`);
+}
+
+/**
+ * Appends a single-line value to the GitHub Actions `GITHUB_OUTPUT` file.
+ *
+ * @param name Output id consumed by workflow `steps.<id>.outputs.<name>`
+ * @param value Scalar output (must not contain raw newlines)
+ */
+export function writeGitHubActionsOutput(name: string, value: string) {
+	writeGitHubActionsOutputToPath(name, value, getCiPollResolveEnv().GITHUB_OUTPUT);
+}
+
+/**
+ * Appends a workflow output without requiring poll/resolve script credentials.
+ *
+ * @param name Output id consumed by workflow `steps.<id>.outputs.<name>`
+ * @param value Scalar output (must not contain raw newlines)
+ */
+export function writeCiWorkflowOutput(name: string, value: string) {
+	writeGitHubActionsOutputToPath(name, value, getCiWorkflowOutputEnv().GITHUB_OUTPUT);
 }

--- a/src/ci/utils/resolve-translation-targets.util.ts
+++ b/src/ci/utils/resolve-translation-targets.util.ts
@@ -1,0 +1,31 @@
+import { collectTranslationFilePaths } from "@/app/utils/parse-translation-file-paths.util";
+
+/** Resolved translation target inputs for workflow dispatch */
+export interface ResolvedTranslationTargets {
+	/** Trimmed manual `file_path` input for optional `--file` forwarding */
+	path: string;
+	/** Whether any configured target path limits the run */
+	hasTargetPaths: boolean;
+}
+
+/**
+ * Resolves workflow translation targets from manual input and environment.
+ *
+ * @param options Manual `file_path` input and optional `TRANSLATION_FILE_PATHS` env value
+ * @param options.filePathInput Trimmed workflow `file_path` dispatch input
+ * @param options.translationFilePathsEnv Raw `TRANSLATION_FILE_PATHS` environment value
+ *
+ * @returns Trimmed manual path and whether targeted re-translation is configured
+ */
+export function resolveTranslationTargets(options: {
+	filePathInput?: string;
+	translationFilePathsEnv?: string;
+}) {
+	const path = (options.filePathInput ?? "").trim();
+	const targetPaths = collectTranslationFilePaths(path, options.translationFilePathsEnv);
+
+	return {
+		path,
+		hasTargetPaths: targetPaths.length > 0,
+	} satisfies ResolvedTranslationTargets;
+}

--- a/tests/app/utils/parse-translation-file-paths.util.spec.ts
+++ b/tests/app/utils/parse-translation-file-paths.util.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	collectTranslationFilePaths,
+	parseTranslationFilePaths,
+} from "@/app/utils/parse-translation-file-paths.util";
+
+const TARGET_PATH = "src/content/reference/rsc/use-client.md";
+const OTHER_PATH = "src/content/blog/post.md";
+
+describe("parseTranslationFilePaths", () => {
+	test("returns empty array when input is unset or blank", () => {
+		expect(parseTranslationFilePaths(undefined)).toEqual([]);
+		expect(parseTranslationFilePaths("")).toEqual([]);
+		expect(parseTranslationFilePaths("   ")).toEqual([]);
+	});
+
+	test("parses comma-separated paths and trims whitespace", () => {
+		expect(parseTranslationFilePaths(` ${TARGET_PATH} , ${OTHER_PATH} `)).toEqual([
+			TARGET_PATH,
+			OTHER_PATH,
+		]);
+	});
+
+	test("deduplicates repeated paths while preserving first-seen order", () => {
+		expect(parseTranslationFilePaths(`${TARGET_PATH},${TARGET_PATH},${OTHER_PATH}`)).toEqual([
+			TARGET_PATH,
+			OTHER_PATH,
+		]);
+	});
+});
+
+describe("collectTranslationFilePaths", () => {
+	test("merges input and environment sources without duplicates", () => {
+		expect(collectTranslationFilePaths(` ${TARGET_PATH} `, `${TARGET_PATH},${OTHER_PATH}`)).toEqual(
+			[TARGET_PATH, OTHER_PATH],
+		);
+	});
+
+	test("returns empty array when all sources are blank", () => {
+		expect(collectTranslationFilePaths(undefined, "   ", "")).toEqual([]);
+	});
+});

--- a/tests/app/utils/translation-cli.util.spec.ts
+++ b/tests/app/utils/translation-cli.util.spec.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { applyTranslationCliOverrides } from "@/app/utils/translation-cli.util";
+
+const TARGET_PATH = "src/content/reference/rsc/use-client.md";
+const OTHER_PATH = "src/content/blog/post.md";
+
+describe("applyTranslationCliOverrides", () => {
+	afterEach(() => {
+		delete import.meta.env["TRANSLATION_FILE_PATHS"];
+	});
+
+	test("sets TRANSLATION_FILE_PATHS from a comma-separated --file value", () => {
+		applyTranslationCliOverrides(["--file", `${TARGET_PATH},${OTHER_PATH}`]);
+
+		expect(import.meta.env["TRANSLATION_FILE_PATHS"]).toBe(`${TARGET_PATH},${OTHER_PATH}`);
+	});
+
+	test("merges repeated --file flags into a deduplicated TRANSLATION_FILE_PATHS value", () => {
+		applyTranslationCliOverrides(["--file", TARGET_PATH, "--file", OTHER_PATH, "-f", TARGET_PATH]);
+
+		expect(import.meta.env["TRANSLATION_FILE_PATHS"]).toBe(`${TARGET_PATH},${OTHER_PATH}`);
+	});
+
+	test("does not set TRANSLATION_FILE_PATHS when --file is omitted", () => {
+		applyTranslationCliOverrides(["--lang", "ru"]);
+
+		expect(import.meta.env["TRANSLATION_FILE_PATHS"]).toBeUndefined();
+	});
+});

--- a/tests/app/utils/translation-target.util.spec.ts
+++ b/tests/app/utils/translation-target.util.spec.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	filterToTranslationTargets,
+	findUnsafeTranslationTargetPaths,
+	isForceRetranslatePath,
+	parseTranslationFilePaths,
+	shouldPreserveOpenPullRequestOnRefresh,
+} from "@/app/utils/translation-target.util";
+
+import { createMockPullRequestListItem } from "@tests/fixtures";
+
+const TARGET_PATH = "src/content/reference/rsc/use-client.md";
+const OTHER_PATH = "src/content/blog/post.md";
+
+describe("parseTranslationFilePaths", () => {
+	test("returns empty array when input is unset or blank", () => {
+		expect(parseTranslationFilePaths(undefined)).toEqual([]);
+		expect(parseTranslationFilePaths("")).toEqual([]);
+		expect(parseTranslationFilePaths("   ")).toEqual([]);
+	});
+
+	test("parses comma-separated paths and trims whitespace", () => {
+		expect(parseTranslationFilePaths(` ${TARGET_PATH} , ${OTHER_PATH} `)).toEqual([
+			TARGET_PATH,
+			OTHER_PATH,
+		]);
+	});
+
+	test("deduplicates repeated paths while preserving first-seen order", () => {
+		expect(parseTranslationFilePaths(`${TARGET_PATH},${TARGET_PATH},${OTHER_PATH}`)).toEqual([
+			TARGET_PATH,
+			OTHER_PATH,
+		]);
+	});
+});
+
+describe("isForceRetranslatePath", () => {
+	test("returns false when no target paths are configured", () => {
+		expect(isForceRetranslatePath(TARGET_PATH, [])).toBe(false);
+	});
+
+	test("returns true only for listed target paths", () => {
+		const targets = [TARGET_PATH];
+
+		expect(isForceRetranslatePath(TARGET_PATH, targets)).toBe(true);
+		expect(isForceRetranslatePath(OTHER_PATH, targets)).toBe(false);
+	});
+});
+
+describe("shouldPreserveOpenPullRequestOnRefresh", () => {
+	test("returns false when there is no open pull request", () => {
+		expect(
+			shouldPreserveOpenPullRequestOnRefresh(TARGET_PATH, {
+				pullRequest: undefined,
+				invalidReason: "no_open_pr",
+			}),
+		).toBe(false);
+	});
+
+	test("returns true for out-of-sync pull requests", () => {
+		expect(
+			shouldPreserveOpenPullRequestOnRefresh(TARGET_PATH, {
+				pullRequest: createMockPullRequestListItem(42),
+				invalidReason: "out_of_sync",
+			}),
+		).toBe(true);
+	});
+
+	test("returns true for configured force-retranslate targets with an open pull request", () => {
+		const targets = [TARGET_PATH];
+
+		expect(
+			shouldPreserveOpenPullRequestOnRefresh(
+				TARGET_PATH,
+				{
+					pullRequest: createMockPullRequestListItem(1173),
+					invalidReason: undefined,
+				},
+				targets,
+			),
+		).toBe(true);
+	});
+
+	test("returns false for valid pull requests that are not force-retranslate targets", () => {
+		expect(
+			shouldPreserveOpenPullRequestOnRefresh(
+				OTHER_PATH,
+				{
+					pullRequest: createMockPullRequestListItem(99),
+					invalidReason: undefined,
+				},
+				[TARGET_PATH],
+			),
+		).toBe(false);
+	});
+});
+
+describe("filterToTranslationTargets", () => {
+	test("returns all files when no target paths are configured", () => {
+		const files = [{ path: TARGET_PATH }, { path: OTHER_PATH }];
+
+		expect(filterToTranslationTargets(files, [])).toEqual(files);
+	});
+
+	test("returns only files that match configured target paths", () => {
+		const files = [{ path: TARGET_PATH }, { path: OTHER_PATH }];
+
+		expect(filterToTranslationTargets(files, [TARGET_PATH])).toEqual([{ path: TARGET_PATH }]);
+	});
+});
+
+describe("findUnsafeTranslationTargetPaths", () => {
+	test("flags paths outside safe translatable markdown scope", () => {
+		expect(findUnsafeTranslationTargetPaths(["../secret.md", TARGET_PATH])).toEqual([
+			"../secret.md",
+		]);
+	});
+});

--- a/tests/app/utils/translation-target.util.spec.ts
+++ b/tests/app/utils/translation-target.util.spec.ts
@@ -4,7 +4,6 @@ import {
 	filterToTranslationTargets,
 	findUnsafeTranslationTargetPaths,
 	isForceRetranslatePath,
-	parseTranslationFilePaths,
 	shouldPreserveOpenPullRequestOnRefresh,
 } from "@/app/utils/translation-target.util";
 
@@ -12,28 +11,6 @@ import { createMockPullRequestListItem } from "@tests/fixtures";
 
 const TARGET_PATH = "src/content/reference/rsc/use-client.md";
 const OTHER_PATH = "src/content/blog/post.md";
-
-describe("parseTranslationFilePaths", () => {
-	test("returns empty array when input is unset or blank", () => {
-		expect(parseTranslationFilePaths(undefined)).toEqual([]);
-		expect(parseTranslationFilePaths("")).toEqual([]);
-		expect(parseTranslationFilePaths("   ")).toEqual([]);
-	});
-
-	test("parses comma-separated paths and trims whitespace", () => {
-		expect(parseTranslationFilePaths(` ${TARGET_PATH} , ${OTHER_PATH} `)).toEqual([
-			TARGET_PATH,
-			OTHER_PATH,
-		]);
-	});
-
-	test("deduplicates repeated paths while preserving first-seen order", () => {
-		expect(parseTranslationFilePaths(`${TARGET_PATH},${TARGET_PATH},${OTHER_PATH}`)).toEqual([
-			TARGET_PATH,
-			OTHER_PATH,
-		]);
-	});
-});
 
 describe("isForceRetranslatePath", () => {
 	test("returns false when no target paths are configured", () => {

--- a/tests/ci/schemas/env.schema.spec.ts
+++ b/tests/ci/schemas/env.schema.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { parseCiPollResolveEnvironment, resolveCiScriptContext } from "@/ci/schemas/env.schema";
+import {
+	parseCiPollResolveEnvironment,
+	parseCiWorkflowOutputEnvironment,
+	resolveCiScriptContext,
+} from "@/ci/schemas/env.schema";
 
 describe("ci env.schema", () => {
 	test("parseCiPollResolveEnvironment accepts valid workflow script variables", () => {
@@ -22,6 +26,14 @@ describe("ci env.schema", () => {
 				GITHUB_OUTPUT: "/tmp/github-output",
 			}),
 		).toThrow();
+	});
+
+	test("parseCiWorkflowOutputEnvironment accepts GITHUB_OUTPUT only", () => {
+		expect(
+			parseCiWorkflowOutputEnvironment({
+				GITHUB_OUTPUT: "/tmp/github-output",
+			}).GITHUB_OUTPUT,
+		).toBe("/tmp/github-output");
 	});
 });
 

--- a/tests/ci/utils/resolve-translation-targets.util.spec.ts
+++ b/tests/ci/utils/resolve-translation-targets.util.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveTranslationTargets } from "@/ci/utils/resolve-translation-targets.util";
+
+const TARGET_PATH = "src/content/reference/rsc/use-client.md";
+const OTHER_PATH = "src/content/blog/post.md";
+
+describe("resolveTranslationTargets", () => {
+	test("returns no targets for blank manual input and unset environment", () => {
+		expect(
+			resolveTranslationTargets({
+				filePathInput: "   ",
+			}),
+		).toEqual({
+			path: "",
+			hasTargetPaths: false,
+		});
+	});
+
+	test("marks targeted runs from manual input and forwards trimmed path", () => {
+		expect(
+			resolveTranslationTargets({
+				filePathInput: `  ${TARGET_PATH}  `,
+			}),
+		).toEqual({
+			path: TARGET_PATH,
+			hasTargetPaths: true,
+		});
+	});
+
+	test("marks targeted runs from TRANSLATION_FILE_PATHS without manual input", () => {
+		expect(
+			resolveTranslationTargets({
+				translationFilePathsEnv: OTHER_PATH,
+			}),
+		).toEqual({
+			path: "",
+			hasTargetPaths: true,
+		});
+	});
+
+	test("merges manual input and environment sources", () => {
+		expect(
+			resolveTranslationTargets({
+				filePathInput: TARGET_PATH,
+				translationFilePathsEnv: OTHER_PATH,
+			}),
+		).toEqual({
+			path: TARGET_PATH,
+			hasTargetPaths: true,
+		});
+	});
+});

--- a/tests/helpers/translation-target.harness.ts
+++ b/tests/helpers/translation-target.harness.ts
@@ -1,0 +1,18 @@
+import { afterEach, beforeEach } from "bun:test";
+
+import { testEnv } from "../setup";
+
+/**
+ * Sets `TRANSLATION_FILE_PATHS` on the shared test env for targeted re-translation specs.
+ *
+ * @param paths Repository paths to expose as configured translation targets
+ */
+export function useTranslationTargetPaths(...paths: string[]) {
+	beforeEach(() => {
+		testEnv.TRANSLATION_FILE_PATHS = paths.join(",");
+	});
+
+	afterEach(() => {
+		delete testEnv.TRANSLATION_FILE_PATHS;
+	});
+}

--- a/tests/services/runner/file-discovery.force-retranslate.spec.ts
+++ b/tests/services/runner/file-discovery.force-retranslate.spec.ts
@@ -1,0 +1,156 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type { PatchedRepositoryTreeItem } from "@/app/services/github/types";
+
+import { FileDiscoveryManager } from "@/app/services/runner/workflow/file-discovery.manager";
+
+import {
+	createMockPullRequestListItem,
+	createPullRequestStatusFixture,
+	createRepositoryTreeItemFixture,
+	createTranslatedLanguageAnalysis,
+	createUntranslatedLanguageAnalysis,
+} from "@tests/fixtures";
+import { buildRunnerServiceDependencies } from "@tests/helpers/runner-dependencies.harness";
+import { useTranslationTargetPaths } from "@tests/helpers/translation-target.harness";
+import { createMockGitHubService, createMockLanguageDetectorService } from "@tests/mocks";
+
+const TARGET_PATH = "src/content/reference/rsc/use-client.md";
+const OTHER_PATH = "src/content/blog/post.md";
+
+function createTestFileDiscoveryManager(
+	overrides: Parameters<typeof buildRunnerServiceDependencies>[0] = {},
+) {
+	return new FileDiscoveryManager(buildRunnerServiceDependencies(overrides));
+}
+
+describe("FileDiscoveryManager targeted re-translation", () => {
+	useTranslationTargetPaths(TARGET_PATH);
+
+	describe("filterByPRs", () => {
+		test("includes a valid pull request file when it is a configured force-retranslate target", async () => {
+			const github = createMockGitHubService();
+			const languageDetector = createMockLanguageDetectorService();
+
+			github.findPullRequestByBranch.mockResolvedValue(createMockPullRequestListItem(1173));
+			github.checkPullRequestStatus.mockResolvedValue(createPullRequestStatusFixture());
+			github.getForkFileContentAtBranch.mockResolvedValue(
+				"Достаточно длинный русский текст для детекции языка.",
+			);
+			languageDetector.analyzeLanguage.mockResolvedValue(createTranslatedLanguageAnalysis());
+
+			const manager = createTestFileDiscoveryManager({ github, languageDetector });
+			const candidate = createRepositoryTreeItemFixture({ path: TARGET_PATH });
+
+			const result = await manager.filterByPRs([candidate]);
+
+			expect(result.filesToFetch).toHaveLength(1);
+			expect(result.numFilesWithPRs).toBe(0);
+		});
+
+		test("still skips non-target files that have valid open pull requests", async () => {
+			const github = createMockGitHubService();
+			const languageDetector = createMockLanguageDetectorService();
+
+			github.findPullRequestByBranch.mockResolvedValue(createMockPullRequestListItem(7));
+			github.checkPullRequestStatus.mockResolvedValue(createPullRequestStatusFixture());
+			github.getForkFileContentAtBranch.mockResolvedValue(
+				"Conteúdo em português suficientemente longo para detecção de idioma.",
+			);
+			languageDetector.analyzeLanguage.mockResolvedValue(createTranslatedLanguageAnalysis());
+
+			const manager = createTestFileDiscoveryManager({ github, languageDetector });
+			const candidate = createRepositoryTreeItemFixture({ path: OTHER_PATH });
+
+			const result = await manager.filterByPRs([candidate]);
+
+			expect(result.filesToFetch).toHaveLength(0);
+			expect(result.numFilesWithPRs).toBe(1);
+		});
+	});
+
+	describe("discoverFiles", () => {
+		test("limits discovery to configured target paths", async () => {
+			const github = createMockGitHubService();
+			const languageDetector = createMockLanguageDetectorService();
+
+			github.findPullRequestByBranch.mockResolvedValue(undefined);
+			github.getFile.mockImplementation((treeItem: unknown) => {
+				const item = treeItem as PatchedRepositoryTreeItem;
+
+				return Promise.resolve({
+					path: item.path,
+					filename: item.path.split("/").pop() ?? item.path,
+					content: "# Title\n\nEnglish body content for translation.",
+					sha: item.sha,
+				});
+			});
+			languageDetector.analyzeLanguage.mockResolvedValue(createUntranslatedLanguageAnalysis());
+
+			const manager = createTestFileDiscoveryManager({ github, languageDetector });
+			const tree = [
+				createRepositoryTreeItemFixture({
+					path: TARGET_PATH,
+					filename: "use-client.md",
+				}),
+				createRepositoryTreeItemFixture({
+					path: OTHER_PATH,
+					filename: "post.md",
+				}),
+			];
+
+			const result = await manager.discoverFiles(tree);
+
+			expect(result.filesToTranslate).toHaveLength(1);
+			expect(result.filesToTranslate[0]?.path).toBe(TARGET_PATH);
+		});
+
+		test("returns no files when configured targets are absent from the repository tree", async () => {
+			const manager = createTestFileDiscoveryManager();
+			const tree = [createRepositoryTreeItemFixture({ path: OTHER_PATH })];
+
+			const result = await manager.discoverFiles(tree);
+
+			expect(result.filesToTranslate).toHaveLength(0);
+		});
+	});
+
+	describe("checkCache", () => {
+		test("bypasses cache hits for configured force-retranslate targets", () => {
+			const languageCache = {
+				getMany: mock(
+					() =>
+						new Map([
+							[
+								"use-client.md:abc123",
+								{
+									detectedLanguage: "ru",
+									confidence: 0.99,
+									timestamp: Date.now(),
+								},
+							],
+						]),
+				),
+			};
+			const languageDetector = createMockLanguageDetectorService();
+			languageDetector.languages = { target: "ru", source: "en" };
+
+			const manager = createTestFileDiscoveryManager({
+				languageCache: languageCache as never,
+				languageDetector,
+			});
+			const files = [
+				createRepositoryTreeItemFixture({
+					path: TARGET_PATH,
+					filename: "use-client.md",
+					sha: "abc123",
+				}),
+			];
+
+			const result = manager.checkCache(files);
+
+			expect(result.candidateFiles).toHaveLength(1);
+			expect(result.cacheHits).toBe(0);
+		});
+	});
+});

--- a/tests/services/runner/translation-batch.force-retranslate.spec.ts
+++ b/tests/services/runner/translation-batch.force-retranslate.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+
+import { PullRequestProgressAction } from "@/app/services/github/types";
+import { TranslationBatchManager } from "@/app/services/runner/workflow/translation-batch.manager";
+
+import {
+	createGitBranchRefResponse,
+	createMockPullRequestListItem,
+	createPullRequestStatusFixture,
+	createTranslatedLanguageAnalysis,
+	createTranslationFileFixture,
+} from "@tests/fixtures";
+import { buildRunnerServiceDependencies } from "@tests/helpers/runner-dependencies.harness";
+import { useTranslationTargetPaths } from "@tests/helpers/translation-target.harness";
+import {
+	createMockGitHubService,
+	createMockLanguageDetectorService,
+	createMockTranslatorService,
+} from "@tests/mocks";
+
+const TARGET_PATH = "src/content/reference/rsc/use-client.md";
+
+function createTestTranslationBatchManager(
+	overrides: Parameters<typeof buildRunnerServiceDependencies>[0] = {},
+) {
+	return new TranslationBatchManager(
+		buildRunnerServiceDependencies(overrides),
+		new Map(),
+		Date.now(),
+	);
+}
+
+describe("TranslationBatchManager targeted re-translation", () => {
+	useTranslationTargetPaths(TARGET_PATH);
+
+	test("re-translates a valid open pull request when the file is a configured target", async () => {
+		const github = createMockGitHubService();
+		const translator = createMockTranslatorService();
+		const languageDetector = createMockLanguageDetectorService();
+		const existingPR = createMockPullRequestListItem(1173);
+
+		github.findPullRequestByBranch.mockResolvedValue(existingPR);
+		github.checkPullRequestStatus.mockResolvedValue(createPullRequestStatusFixture());
+		github.getForkFileContentAtBranch.mockResolvedValue(
+			"Достаточно длинный русский текст для детекции языка.",
+		);
+		github.getBranch.mockResolvedValue(createGitBranchRefResponse());
+		languageDetector.analyzeLanguage.mockResolvedValue(createTranslatedLanguageAnalysis());
+
+		const manager = createTestTranslationBatchManager({
+			github,
+			translator,
+			languageDetector,
+		});
+		const file = createTranslationFileFixture({
+			path: TARGET_PATH,
+			filename: "use-client.md",
+		});
+
+		const results = await manager.processBatches([file], 1);
+
+		expect(translator.translateContent).toHaveBeenCalled();
+		expect(github.refreshTranslationBranchPreservePr).toHaveBeenCalled();
+		expect(github.closePullRequest).not.toHaveBeenCalled();
+		expect(github.updatePullRequestBody).toHaveBeenCalled();
+		expect(results.get(file.filename)?.pullRequest).toEqual(existingPR);
+		expect(results.get(file.filename)?.pullRequestProgress).toBe(PullRequestProgressAction.Reused);
+	});
+
+	test("still skips translate when the file is not a configured target", async () => {
+		const github = createMockGitHubService();
+		const translator = createMockTranslatorService();
+		const languageDetector = createMockLanguageDetectorService();
+		const existingPR = createMockPullRequestListItem(1082);
+
+		github.findPullRequestByBranch.mockResolvedValue(existingPR);
+		github.checkPullRequestStatus.mockResolvedValue(createPullRequestStatusFixture());
+		github.getForkFileContentAtBranch.mockResolvedValue(
+			"Conteúdo em português suficientemente longo para detecção de idioma.",
+		);
+		languageDetector.analyzeLanguage.mockResolvedValue(createTranslatedLanguageAnalysis());
+
+		const manager = createTestTranslationBatchManager({
+			github,
+			translator,
+			languageDetector,
+		});
+		const file = createTranslationFileFixture({
+			path: "src/content/blog/post.md",
+			filename: "post.md",
+		});
+
+		await manager.processBatches([file], 1);
+
+		expect(translator.translateContent).not.toHaveBeenCalled();
+		expect(github.refreshTranslationBranchPreservePr).not.toHaveBeenCalled();
+	});
+});

--- a/tests/services/runner/translation-branch.lifecycle.manager.spec.ts
+++ b/tests/services/runner/translation-branch.lifecycle.manager.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+
+import { TranslationBranchLifecycleManager } from "@/app/services/runner/workflow/translation-branch.lifecycle.manager";
+
+import { createMockPullRequestListItem, createTranslationFileFixture } from "@tests/fixtures";
+import { buildRunnerServiceDependencies } from "@tests/helpers/runner-dependencies.harness";
+import { useTranslationTargetPaths } from "@tests/helpers/translation-target.harness";
+import { createMockGitHubService } from "@tests/mocks";
+
+const TARGET_PATH = "src/content/reference/rsc/use-client.md";
+
+describe("TranslationBranchLifecycleManager", () => {
+	useTranslationTargetPaths(TARGET_PATH);
+
+	describe("prepareTranslationBranch", () => {
+		test("preserves an open pull request when force-retranslating a configured target", async () => {
+			const github = createMockGitHubService();
+			github.refreshTranslationBranchPreservePr.mockResolvedValue({
+				ref: "refs/heads/translate/reference/rsc/use-client.md",
+				object: { sha: "refreshed-sha" },
+			});
+
+			const manager = new TranslationBranchLifecycleManager(
+				buildRunnerServiceDependencies({ github }),
+			);
+			const file = createTranslationFileFixture({
+				path: TARGET_PATH,
+				filename: "use-client.md",
+			});
+			const existingPR = createMockPullRequestListItem(1173);
+			const validity = {
+				isValid: true,
+				pullRequest: existingPR,
+				invalidReason: undefined,
+			};
+
+			await manager.prepareTranslationBranch(file, validity);
+
+			expect(github.refreshTranslationBranchPreservePr).toHaveBeenCalledWith(
+				"translate/reference/rsc/use-client.md",
+			);
+			expect(github.closePullRequest).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/tests/services/runner/translation-pull-request.lifecycle.manager.spec.ts
+++ b/tests/services/runner/translation-pull-request.lifecycle.manager.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+
+import { PullRequestProgressAction } from "@/app/services/github/types";
+import { TranslationPullRequestLifecycleManager } from "@/app/services/runner/workflow/translation-pull-request.lifecycle.manager";
+
+import {
+	createMockPullRequestListItem,
+	createProcessedFileResultsFixture,
+	createTranslationFileFixture,
+} from "@tests/fixtures";
+import { buildRunnerServiceDependencies } from "@tests/helpers/runner-dependencies.harness";
+import { useTranslationTargetPaths } from "@tests/helpers/translation-target.harness";
+import { createMockGitHubService } from "@tests/mocks";
+
+const TARGET_PATH = "src/content/reference/rsc/use-client.md";
+
+describe("TranslationPullRequestLifecycleManager", () => {
+	useTranslationTargetPaths(TARGET_PATH);
+
+	describe("openTranslationPullRequest", () => {
+		test("reuses and refreshes the body for a force-retranslate target with a valid open pull request", async () => {
+			const github = createMockGitHubService();
+			const manager = new TranslationPullRequestLifecycleManager(
+				buildRunnerServiceDependencies({ github }),
+				new Map(),
+			);
+			const file = createTranslationFileFixture({
+				path: TARGET_PATH,
+				filename: "use-client.md",
+			});
+			const existingPR = createMockPullRequestListItem(1173);
+			const processingResults = createProcessedFileResultsFixture({ count: 1 });
+			expect(processingResults).toHaveLength(1);
+			const processingResult = processingResults[0];
+
+			if (!processingResult) {
+				throw new Error("Expected processed file result fixture");
+			}
+
+			processingResult.translation = "# Перевод\n\nОбновлённый текст.";
+
+			const outcome = await manager.openTranslationPullRequest(file, processingResult, {
+				isValid: true,
+				pullRequest: existingPR,
+			});
+
+			expect(github.updatePullRequestBody).toHaveBeenCalled();
+			expect(github.createPullRequest).not.toHaveBeenCalled();
+			expect(outcome.pullRequest).toEqual(existingPR);
+			expect(outcome.progress).toBe(PullRequestProgressAction.Reused);
+		});
+	});
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core runner discovery and PR/branch lifecycle plus upstream SHA recording; behavior is well covered by new tests but mistakes could skip full syncs or refresh wrong PRs.
> 
> **Overview**
> **Release 0.2.11** adds **targeted file re-translation**: operators can limit a run to specific `src/**/*.md` paths via `--file` / `-f`, `TRANSLATION_FILE_PATHS`, or manual workflow `file_path`. Discovery, cache, and valid-PR skip logic honor those targets so listed files are re-translated even when an open translation PR already exists; branch and PR lifecycle **refresh the existing PR in place** instead of closing it.
> 
> Manual **translation workflow** resolves targets through `ci:resolve-translation-targets`, forwards `--file` when set, and **does not record upstream locale SHA** on targeted runs so poll baselines are not advanced by a single-file refresh.
> 
> **CI** runs real-LLM workflow smoke **only on pull requests** (not on pushes to `main`/`dev`). Manual **Smoke** dispatch gains a **`lang`** input and locale-aware artifact names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcf1fe09cf8aca13033997c92039d6a6d30fed76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->