### PR TITLE
release `0.2.12`

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,4 +1,4 @@
-name: Smoke
+name: Smoke Workflow
 
 on:
   workflow_dispatch:
@@ -22,7 +22,7 @@ on:
           - production
         default: development
       lang:
-        description: Target locale for smoke run (from .github/locales.json)
+        description: Target locale for the smoke run
         required: false
         type: choice
         options:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -23,12 +23,12 @@ on:
           - production
         default: development
       langs:
-        description: Comma-separated locale ids (empty = all configured upstream locales)
+        description: Comma-separated locale ids (empty = all configured locales)
         required: false
         type: string
         default: ""
       file_path:
-        description: Optional repository path for targeted re-translation (preserves open PR)
+        description: Optional repository path for targeted re-translation
         required: false
         type: string
         default: ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ## [Unreleased]
 
+## [0.2.12] - 2026-07-07
+
 ### Changed
 
 - ESLint requires a blank line before each JSDoc block that follows another member, including single-line property docs on interfaces and types.
@@ -344,6 +346,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 - README `MAX_RETRY_ATTEMPTS` default matches runtime (`3`).
 
+[0.2.12]: https://github.com/NivaldoFarias/translate-react/releases/tag/v0.2.12
 [0.2.11]: https://github.com/NivaldoFarias/translate-react/releases/tag/v0.2.11
 [0.2.10]: https://github.com/NivaldoFarias/translate-react/releases/tag/v0.2.10
 [0.2.9]: https://github.com/NivaldoFarias/translate-react/releases/tag/v0.2.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ## [Unreleased]
 
+### Changed
+
+- ESLint requires a blank line before each JSDoc block that follows another member, including single-line property docs on interfaces and types.
+
+### Fixed
+
+- `verifyLLMConnectivity()` no longer fails on providers that require at least 16 output tokens; `CONNECTIVITY_TEST_MAX_TOKENS` is raised from 5 to 32.
+- OpenRouter LLM API errors log parsed `providerMetadata` and nested `providerMessage` text instead of stringified JSON blobs.
+
 ## [0.2.11] - 2026-07-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Changed
 
+- Russian translation prompts now steer idiomatic English phrases toward natural Russian (for example `null prototype`, `client-marked code`, Server Component defaults, latency and rendering calques, and `tree graph` alt text) so regenerated `ru` pages read less like word-for-word machine translation.
 - ESLint requires a blank line before each JSDoc block that follows another member, including single-line property docs on interfaces and types.
 
 ### Fixed

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -87,6 +87,32 @@ export default defineConfig(
 					],
 				},
 			],
+			"jsdoc/require-jsdoc": [
+				"error",
+				{
+					publicOnly: true,
+					contexts: [
+						"TSInterfaceDeclaration",
+						"TSMethodSignature",
+						"TSTypeAliasDeclaration",
+						{
+							context: "TSPropertySignature",
+							inlineCommentBlock: true,
+						},
+					],
+				},
+			],
+			"jsdoc/require-description": [
+				"error",
+				{
+					contexts: [
+						"TSInterfaceDeclaration",
+						"TSPropertySignature",
+						"TSMethodSignature",
+						"TSTypeAliasDeclaration",
+					],
+				},
+			],
 		},
 	},
 	{

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -71,6 +71,7 @@ export default defineConfig(
 			/* JSDoc */
 			"jsdoc/no-undefined-types": ["error", { disableReporting: true, markVariablesAsUsed: true }],
 			"jsdoc/tag-lines": ["error", "any", { startLines: 1 }],
+			"jsdoc/lines-before-block": ["error", { ignoreSingleLines: false }],
 			"jsdoc/sort-tags": [
 				"error",
 				{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "translate-react",
-	"version": "0.2.11",
+	"version": "0.2.12",
 	"contributors": [
 		{
 			"name": "Nivaldo Farias",

--- a/src/app/constants/environment.constants.ts
+++ b/src/app/constants/environment.constants.ts
@@ -8,44 +8,64 @@ import { LogLevel, RuntimeEnvironment } from "./runtime.constants";
 export interface EnvironmentSchemaDefaults {
 	/** Active Node runtime environment */
 	NODE_ENV: RuntimeEnvironment;
+
 	/** Minimum Pino log level */
 	LOG_LEVEL: LogLevel;
+
 	/** GitHub API token for Octokit */
 	GH_TOKEN: string;
+
 	/** API key for the OpenAI-compatible LLM provider */
 	LLM_API_KEY: string;
+
 	/** Optional OpenAI project id request header */
 	OPENAI_PROJECT_ID: string;
+
 	/** Base URL for the LLM API */
 	LLM_API_BASE_URL: string;
+
 	/** Application title sent in outbound HTTP headers */
 	HEADER_APP_TITLE: string;
+
 	/** Application homepage URL sent in outbound HTTP headers */
 	HEADER_APP_URL: string;
+
 	/** Fork repository owner */
 	REPO_FORK_OWNER: string;
+
 	/** Fork repository name */
 	REPO_FORK_NAME: string;
+
 	/** Upstream repository owner */
 	REPO_UPSTREAM_OWNER: string;
+
 	/** Upstream repository name */
 	REPO_UPSTREAM_NAME: string;
+
 	/** Model id sent to the LLM provider */
 	LLM_MODEL: string;
+
 	/** Number of files processed per translation batch */
 	BATCH_SIZE: number;
+
 	/** Target translation locale code */
 	TARGET_LANGUAGE: ReactLanguageCode;
+
 	/** Source document locale code */
 	SOURCE_LANGUAGE: ReactLanguageCode;
+
 	/** Maximum completion tokens per LLM call */
 	MAX_TOKENS: number;
+
 	/** Whether Pino mirrors logs to stdout */
 	LOG_TO_CONSOLE: boolean;
+
 	/** Octokit request timeout in milliseconds */
 	GH_REQUEST_TIMEOUT: number;
+
 	/** Maximum concurrent in-flight LLM requests */
 	MAX_LLM_CONCURRENCY: number;
+
 	/** Maximum p-retry attempts per LLM chat completion on transient API errors */
 	MAX_RETRY_ATTEMPTS: number;
 

--- a/src/app/constants/environment.constants.ts
+++ b/src/app/constants/environment.constants.ts
@@ -4,26 +4,47 @@ import type { ReactLanguageCode } from "./react-translation.constants";
 
 import { LogLevel, RuntimeEnvironment } from "./runtime.constants";
 
+/** Default values and types for the application environment schema */
 export interface EnvironmentSchemaDefaults {
+	/** Active Node runtime environment */
 	NODE_ENV: RuntimeEnvironment;
+	/** Minimum Pino log level */
 	LOG_LEVEL: LogLevel;
+	/** GitHub API token for Octokit */
 	GH_TOKEN: string;
+	/** API key for the OpenAI-compatible LLM provider */
 	LLM_API_KEY: string;
+	/** Optional OpenAI project id request header */
 	OPENAI_PROJECT_ID: string;
+	/** Base URL for the LLM API */
 	LLM_API_BASE_URL: string;
+	/** Application title sent in outbound HTTP headers */
 	HEADER_APP_TITLE: string;
+	/** Application homepage URL sent in outbound HTTP headers */
 	HEADER_APP_URL: string;
+	/** Fork repository owner */
 	REPO_FORK_OWNER: string;
+	/** Fork repository name */
 	REPO_FORK_NAME: string;
+	/** Upstream repository owner */
 	REPO_UPSTREAM_OWNER: string;
+	/** Upstream repository name */
 	REPO_UPSTREAM_NAME: string;
+	/** Model id sent to the LLM provider */
 	LLM_MODEL: string;
+	/** Number of files processed per translation batch */
 	BATCH_SIZE: number;
+	/** Target translation locale code */
 	TARGET_LANGUAGE: ReactLanguageCode;
+	/** Source document locale code */
 	SOURCE_LANGUAGE: ReactLanguageCode;
+	/** Maximum completion tokens per LLM call */
 	MAX_TOKENS: number;
+	/** Whether Pino mirrors logs to stdout */
 	LOG_TO_CONSOLE: boolean;
+	/** Octokit request timeout in milliseconds */
 	GH_REQUEST_TIMEOUT: number;
+	/** Maximum concurrent in-flight LLM requests */
 	MAX_LLM_CONCURRENCY: number;
 	/** Maximum p-retry attempts per LLM chat completion on transient API errors */
 	MAX_RETRY_ATTEMPTS: number;

--- a/src/app/locales/ru.locale.ts
+++ b/src/app/locales/ru.locale.ts
@@ -86,7 +86,15 @@ export const ruLocale: LocaleDefinition = {
 - ALWAYS use the letter 'ё' where standard Russian spelling requires it (e.g. 'определён', 'объём', 'жёлтый', 'начнёт'), not the substitute 'е'
 - ALWAYS use Russian guillemets («») for quotation marks, never straight double quotes (")
 - Translate 'bundler' as 'бандлер', not 'сборщик'
-- Use lowercase for 'серверные компоненты' (Server Components) and 'клиентские компоненты' (Client Components), consistent with other compound terms like 'дочерний компонент' and 'классовый компонент'; do not capitalize each word or use 'Компонент Сервера' / 'Компонент Клиента'`,
+- Use lowercase for 'серверные компоненты' (Server Components) and 'клиентские компоненты' (Client Components), consistent with other compound terms like 'дочерний компонент' and 'классовый компонент'; do not capitalize each word or use 'Компонент Сервера' / 'Компонент Клиента'
+# SEMANTIC TRANSLATION (avoid calques)
+- Translate 'null prototype' as 'прототип null' or 'прототипом null', not 'нулевой прототип' or 'нулевого прототипа' (zero prototype is a different concept)
+- Translate 'client-marked code' with natural Russian grammar, e.g. 'код, помеченный как клиентский' or 'из кода, помеченного как клиентский', not broken phrases like 'импортированный из помеченного клиента кода'
+- Avoid calques for 'may experience low latency'; prefer natural phrasing about lower latency for data retrieval and network requests, not 'могут испытывать низкую задержку'
+- Avoid calques for 'agnostic about where they render'; prefer 'не зависят от того, где они рендерятся', not 'могут быть агностиками к тому, где они рендерятся'
+- Translate 'as Server Components are default' as 'по умолчанию компоненты являются серверными', not 'Компоненты Сервера являются стандартными'
+- In diagram or illustration alt text, translate 'tree graph' as 'древовидный граф' or 'дерево', not 'график дерева' (график implies a chart or plot)
+- When English says 'As dependencies of ComponentA, depB and depC', preserve that depB and depC are dependencies of ComponentA, not three parallel list items`,
 	},
 	pullRequest: {
 		title: (file: TranslationFile) => `Перевод \`${file.filename}\` на русский язык`,

--- a/src/app/locales/types.ts
+++ b/src/app/locales/types.ts
@@ -10,13 +10,17 @@ export type { ReviewerValidationNotice };
 
 /** Prior invalid PR for the same file path */
 export interface InvalidFilePullRequest {
+	/** GitHub pull request number */
 	prNumber: number;
+	/** Mergeability and conflict status of the invalid pull request */
 	status: PullRequestStatus;
 }
 
 /** Inputs for locale-specific pull request body templates */
 export interface PullRequestDescriptionMetadata {
+	/** Human-readable target language name for PR copy */
 	languageName: string;
+	/** Prior invalid pull request for the same file, if any */
 	invalidFilePR: InvalidFilePullRequest | undefined;
 
 	/** Advisory post-translation guard hints for maintainers (empty if clean) */
@@ -155,6 +159,7 @@ export interface LocalePRBodyStrings {
 	};
 }
 
+/** Pull request title and body templates for one target locale */
 export interface LocalePullRequestConfig {
 	/**
 	 * Title template for the pull request in the target language.

--- a/src/app/locales/types.ts
+++ b/src/app/locales/types.ts
@@ -12,6 +12,7 @@ export type { ReviewerValidationNotice };
 export interface InvalidFilePullRequest {
 	/** GitHub pull request number */
 	prNumber: number;
+
 	/** Mergeability and conflict status of the invalid pull request */
 	status: PullRequestStatus;
 }
@@ -20,6 +21,7 @@ export interface InvalidFilePullRequest {
 export interface PullRequestDescriptionMetadata {
 	/** Human-readable target language name for PR copy */
 	languageName: string;
+
 	/** Prior invalid pull request for the same file, if any */
 	invalidFilePR: InvalidFilePullRequest | undefined;
 

--- a/src/app/schemas/env.schema.ts
+++ b/src/app/schemas/env.schema.ts
@@ -12,6 +12,7 @@ import {
 import { createGithubTokenSchema } from "@/shared/schemas/github-token.schema";
 
 const envDefaults = resolveEnvDefaults();
+
 /** Environment configuration schema for runtime validation */
 const envSchema = z.object({
 	/** Node.js's runtime environment */

--- a/src/app/services/comment-builder/comment-builder.service.ts
+++ b/src/app/services/comment-builder/comment-builder.service.ts
@@ -12,6 +12,7 @@ import { selectProgressCommentPayload } from "./progress-comment.util";
 export interface FileEntry {
 	/** File identity used to build hierarchical progress comments */
 	file: TranslationProgressFileRef;
+
 	/** GitHub pull request number opened or updated for the file */
 	prNumber: number;
 }

--- a/src/app/services/comment-builder/comment-builder.service.ts
+++ b/src/app/services/comment-builder/comment-builder.service.ts
@@ -8,17 +8,24 @@ import { logger, resolveGitHubActionsRunContext } from "@/app/utils/";
 
 import { selectProgressCommentPayload } from "./progress-comment.util";
 
+/** One translated file and its pull request number for progress comments */
 export interface FileEntry {
+	/** File identity used to build hierarchical progress comments */
 	file: TranslationProgressFileRef;
+	/** GitHub pull request number opened or updated for the file */
 	prNumber: number;
 }
 
+/** Nested directory tree of translation progress file entries */
 export interface HierarchicalStructure {
+	/** Leaf files at this directory level */
 	files?: FileEntry[];
 	[key: string]: HierarchicalStructure | FileEntry[] | undefined;
 }
 
+/** File entry with repository path segments for tree rendering */
 export interface FileWithHierarchy extends FileEntry {
+	/** Path segments derived from the repository file path */
 	pathParts: string[];
 }
 

--- a/src/app/services/comment-builder/progress-comment.util.ts
+++ b/src/app/services/comment-builder/progress-comment.util.ts
@@ -6,6 +6,7 @@ import { PullRequestProgressAction } from "@/app/services/github/types";
 export interface ProgressCommentSectionPayload {
 	/** Batch results included in this progress section */
 	reportableResults: ProcessedFileResult[];
+
 	/** Translation files paired with {@link ProgressCommentSectionPayload.reportableResults} */
 	reportableFiles: readonly TranslationProgressFileRef[];
 }
@@ -14,6 +15,7 @@ export interface ProgressCommentSectionPayload {
 export interface ProgressCommentPayload {
 	/** Pull requests newly opened in this workflow run */
 	created: ProgressCommentSectionPayload;
+
 	/** Existing pull requests refreshed with new commits in this run */
 	updated: ProgressCommentSectionPayload;
 }

--- a/src/app/services/comment-builder/progress-comment.util.ts
+++ b/src/app/services/comment-builder/progress-comment.util.ts
@@ -4,13 +4,17 @@ import { PullRequestProgressAction } from "@/app/services/github/types";
 
 /** One progress-comment section (created or updated pull requests) */
 export interface ProgressCommentSectionPayload {
+	/** Batch results included in this progress section */
 	reportableResults: ProcessedFileResult[];
+	/** Translation files paired with {@link ProgressCommentSectionPayload.reportableResults} */
 	reportableFiles: readonly TranslationProgressFileRef[];
 }
 
 /** Created and updated pull request groups for the translation-progress issue comment */
 export interface ProgressCommentPayload {
+	/** Pull requests newly opened in this workflow run */
 	created: ProgressCommentSectionPayload;
+	/** Existing pull requests refreshed with new commits in this run */
 	updated: ProgressCommentSectionPayload;
 }
 

--- a/src/app/services/github/types.ts
+++ b/src/app/services/github/types.ts
@@ -51,6 +51,7 @@ export interface TranslationProgressFileRef {
 export interface RepositoryMetadata {
 	/** Repository owner login or organization */
 	owner: components["parameters"]["owner"];
+
 	/** Repository name without owner prefix */
 	repo: components["parameters"]["repo"];
 	[key: string]: unknown;
@@ -60,6 +61,7 @@ export interface RepositoryMetadata {
 export interface BaseRepositories {
 	/** Source React docs repository coordinates */
 	upstream: RepositoryMetadata;
+
 	/** Target-language fork repository coordinates */
 	fork: RepositoryMetadata;
 }
@@ -68,6 +70,7 @@ export interface BaseRepositories {
 export interface SharedGitHubDependencies {
 	/** Authenticated Octokit REST client */
 	octokit: Octokit;
+
 	/** Upstream and fork repository coordinates */
 	repositories: BaseRepositories;
 }

--- a/src/app/services/github/types.ts
+++ b/src/app/services/github/types.ts
@@ -49,20 +49,26 @@ export interface TranslationProgressFileRef {
 
 /** GitHub repository metadata for fork and upstream repositories */
 export interface RepositoryMetadata {
+	/** Repository owner login or organization */
 	owner: components["parameters"]["owner"];
+	/** Repository name without owner prefix */
 	repo: components["parameters"]["repo"];
 	[key: string]: unknown;
 }
 
 /** Upstream and fork repository coordinates shared across GitHub sub-services */
 export interface BaseRepositories {
+	/** Source React docs repository coordinates */
 	upstream: RepositoryMetadata;
+	/** Target-language fork repository coordinates */
 	fork: RepositoryMetadata;
 }
 
 /** Dependencies shared by every GitHub sub-service composed by {@link GitHubService} */
 export interface SharedGitHubDependencies {
+	/** Authenticated Octokit REST client */
 	octokit: Octokit;
+	/** Upstream and fork repository coordinates */
 	repositories: BaseRepositories;
 }
 
@@ -123,6 +129,7 @@ export interface ProcessedFileResult {
 export type RepositoryTreeItem =
 	RestEndpointMethodTypes["git"]["getTree"]["response"]["data"]["tree"][number];
 
+/** Repository tree item with required path and sha plus derived filename */
 export interface PatchedRepositoryTreeItem extends SetRequired<RepositoryTreeItem, "path" | "sha"> {
 	/** Filename extracted from the file path */
 	filename: string;

--- a/src/app/services/language-detector/language-detector.service.ts
+++ b/src/app/services/language-detector/language-detector.service.ts
@@ -67,7 +67,9 @@ function stripHtmlLikeTags(content: string) {
  * ```
  */
 export interface LanguageConfig {
+	/** Expected source document locale code */
 	source: ReactLanguageCode;
+	/** Target translation locale code */
 	target: ReactLanguageCode;
 }
 

--- a/src/app/services/language-detector/language-detector.service.ts
+++ b/src/app/services/language-detector/language-detector.service.ts
@@ -69,6 +69,7 @@ function stripHtmlLikeTags(content: string) {
 export interface LanguageConfig {
 	/** Expected source document locale code */
 	source: ReactLanguageCode;
+
 	/** Target translation locale code */
 	target: ReactLanguageCode;
 }

--- a/src/app/services/openrouter/openrouter.schemas.ts
+++ b/src/app/services/openrouter/openrouter.schemas.ts
@@ -79,4 +79,5 @@ export const openRouterModelsListSchema = z.object({
 	data: z.array(openRouterModelRowSchema),
 });
 
+/** One model row from the OpenRouter models list API */
 export type OpenRouterModelRow = z.infer<typeof openRouterModelRowSchema>;

--- a/src/app/services/runner/runner.service.ts
+++ b/src/app/services/runner/runner.service.ts
@@ -3,7 +3,7 @@ import type { WorkflowStatistics } from "@/app/services/runner/types";
 import type { RunnerOptions, RunnerServiceDependencies } from "./runner.types";
 
 import { logger } from "@/app/utils/";
-import { extractErrorMessage } from "@/shared/errors/";
+import { toSafeErrorLogFields } from "@/shared/errors/";
 
 import { BaseRunnerService } from "./base.service";
 
@@ -75,7 +75,7 @@ export class RunnerService extends BaseRunnerService {
 
 			return this.printFinalStatistics();
 		} catch (error) {
-			this.logger.error({ error: extractErrorMessage(error) }, "Translation workflow failed");
+			this.logger.error(toSafeErrorLogFields(error), "Translation workflow failed");
 
 			throw error;
 		}

--- a/src/app/services/runner/runner.types.ts
+++ b/src/app/services/runner/runner.types.ts
@@ -38,10 +38,15 @@ export interface RunnerServiceDependencies {
 	languageDetector: LanguageDetectorService;
 }
 
+/** Mutable workflow state accumulated across runner stages */
 export interface RunnerState {
+	/** Latest upstream repository tree used for discovery */
 	repositoryTree: PatchedRepositoryTreeItem[];
+	/** Files selected for translation in the current run */
 	filesToTranslate: TranslationFile[];
+	/** Per-file outcomes from batch processing */
 	processedResults: ProcessedFileResult[];
+	/** Unix timestamp when the state snapshot was captured */
 	timestamp: number;
 
 	/**
@@ -50,5 +55,13 @@ export interface RunnerState {
 	 * Tracks files that have existing PRs with conflicts or unmergeable status.
 	 * Used to add informational notes when creating new PRs for these files.
 	 */
-	invalidPRsByFile?: Map<string, { prNumber: number; status: PullRequestStatus }>;
+	invalidPRsByFile?: Map<
+		string,
+		{
+			/** GitHub pull request number for the invalid translation PR */
+			prNumber: number;
+			/** Mergeability and conflict status of the invalid pull request */
+			status: PullRequestStatus;
+		}
+	>;
 }

--- a/src/app/services/runner/runner.types.ts
+++ b/src/app/services/runner/runner.types.ts
@@ -42,10 +42,13 @@ export interface RunnerServiceDependencies {
 export interface RunnerState {
 	/** Latest upstream repository tree used for discovery */
 	repositoryTree: PatchedRepositoryTreeItem[];
+
 	/** Files selected for translation in the current run */
 	filesToTranslate: TranslationFile[];
+
 	/** Per-file outcomes from batch processing */
 	processedResults: ProcessedFileResult[];
+
 	/** Unix timestamp when the state snapshot was captured */
 	timestamp: number;
 
@@ -60,6 +63,7 @@ export interface RunnerState {
 		{
 			/** GitHub pull request number for the invalid translation PR */
 			prNumber: number;
+
 			/** Mergeability and conflict status of the invalid pull request */
 			status: PullRequestStatus;
 		}

--- a/src/app/services/translator/llm/segment-batch-id-match.util.ts
+++ b/src/app/services/translator/llm/segment-batch-id-match.util.ts
@@ -10,14 +10,19 @@ export interface SegmentBatchResponseIdRow {
 export interface SegmentBatchIdMismatchDiagnostics {
 	/** Number of segment ids sent in the request */
 	readonly requestedCount: number;
+
 	/** Number of response rows returned by the model */
 	readonly receivedItemCount: number;
+
 	/** Number of distinct segment ids in the response */
 	readonly uniqueReceivedCount: number;
+
 	/** Requested ids missing from the response */
 	readonly missingIds: string[];
+
 	/** Response ids not present in the request */
 	readonly extraIds: string[];
+
 	/** Response ids that appeared more than once */
 	readonly duplicateResponseIds: string[];
 }

--- a/src/app/services/translator/llm/segment-batch-id-match.util.ts
+++ b/src/app/services/translator/llm/segment-batch-id-match.util.ts
@@ -2,16 +2,23 @@ import type { SegmentBatchRequestItem } from "@/app/services/translator/translat
 
 /** One row in a segment batch LLM response used for id-set comparison */
 export interface SegmentBatchResponseIdRow {
+	/** Segment id echoed by the model for one translated row */
 	readonly segmentId: string;
 }
 
 /** Diff between requested segment ids and ids returned by the model */
 export interface SegmentBatchIdMismatchDiagnostics {
+	/** Number of segment ids sent in the request */
 	readonly requestedCount: number;
+	/** Number of response rows returned by the model */
 	readonly receivedItemCount: number;
+	/** Number of distinct segment ids in the response */
 	readonly uniqueReceivedCount: number;
+	/** Requested ids missing from the response */
 	readonly missingIds: string[];
+	/** Response ids not present in the request */
 	readonly extraIds: string[];
+	/** Response ids that appeared more than once */
 	readonly duplicateResponseIds: string[];
 }
 

--- a/src/app/services/translator/llm/translation-llm.usage.ts
+++ b/src/app/services/translator/llm/translation-llm.usage.ts
@@ -17,9 +17,13 @@ export interface TranslationLlmUsageTotals {
 
 /** Single completion usage snapshot */
 export interface TranslationLlmUsageSnapshot {
+	/** Prompt tokens reported for one completion */
 	readonly promptTokens: number;
+	/** Completion tokens reported for one completion */
 	readonly completionTokens: number;
+	/** Total tokens reported for one completion */
 	readonly totalTokens: number;
+	/** OpenRouter `usage.cost` for one completion, if reported */
 	readonly costUsd: number | null;
 }
 

--- a/src/app/services/translator/llm/translation-llm.usage.ts
+++ b/src/app/services/translator/llm/translation-llm.usage.ts
@@ -19,10 +19,13 @@ export interface TranslationLlmUsageTotals {
 export interface TranslationLlmUsageSnapshot {
 	/** Prompt tokens reported for one completion */
 	readonly promptTokens: number;
+
 	/** Completion tokens reported for one completion */
 	readonly completionTokens: number;
+
 	/** Total tokens reported for one completion */
 	readonly totalTokens: number;
+
 	/** OpenRouter `usage.cost` for one completion, if reported */
 	readonly costUsd: number | null;
 }

--- a/src/app/services/translator/llm/translation-system-prompt.types.ts
+++ b/src/app/services/translator/llm/translation-system-prompt.types.ts
@@ -4,7 +4,9 @@
  * Omitted for whole-file translation and for small frontmatter scalar calls.
  */
 export type ChunkTranslationProgress = Readonly<{
+	/** One-based index of the chunk being translated */
 	index: number;
+	/** Total number of chunks for the document body */
 	total: number;
 }>;
 

--- a/src/app/services/translator/llm/translation-system-prompt.types.ts
+++ b/src/app/services/translator/llm/translation-system-prompt.types.ts
@@ -6,6 +6,7 @@
 export type ChunkTranslationProgress = Readonly<{
 	/** One-based index of the chunk being translated */
 	index: number;
+
 	/** Total number of chunks for the document body */
 	total: number;
 }>;

--- a/src/app/services/translator/markdown/frontmatter.ts
+++ b/src/app/services/translator/markdown/frontmatter.ts
@@ -9,6 +9,7 @@ import { MARKDOWN_REGEXES } from "./markdown.regexes";
 export interface LeadingYamlFrontmatterSplit {
 	/** Matched `---` … `---` prefix when present at document start; otherwise empty */
 	readonly block: string;
+
 	/** Document text after the frontmatter block, or the full `source` when none was split */
 	readonly rest: string;
 }

--- a/src/app/services/translator/markdown/segments/mdast-segment.util.ts
+++ b/src/app/services/translator/markdown/segments/mdast-segment.util.ts
@@ -27,8 +27,11 @@ export type PolicyMdxJsxType = MdxJsxFlowElement["type"] | MdxJsxTextElement["ty
 
 /** Absolute source span for byte-stable segment reinsertion */
 export interface AbsoluteSourceSpan {
+	/** Inclusive start byte offset in the source document */
 	readonly start: number;
+	/** Exclusive end byte offset in the source document */
 	readonly end: number;
+	/** Source substring covered by the span */
 	readonly sourceText: string;
 }
 

--- a/src/app/services/translator/markdown/segments/mdast-segment.util.ts
+++ b/src/app/services/translator/markdown/segments/mdast-segment.util.ts
@@ -29,8 +29,10 @@ export type PolicyMdxJsxType = MdxJsxFlowElement["type"] | MdxJsxTextElement["ty
 export interface AbsoluteSourceSpan {
 	/** Inclusive start byte offset in the source document */
 	readonly start: number;
+
 	/** Exclusive end byte offset in the source document */
 	readonly end: number;
+
 	/** Source substring covered by the span */
 	readonly sourceText: string;
 }

--- a/src/app/services/translator/markdown/segments/types.ts
+++ b/src/app/services/translator/markdown/segments/types.ts
@@ -5,8 +5,10 @@ export type SegmentKind = "translate" | "preserve" | "policy";
 export interface SegmentContext {
 	/** Nearest heading text when the segment sits under a heading */
 	readonly heading?: string;
+
 	/** Fence language tag when the segment is inside a code block */
 	readonly fenceLang?: string;
+
 	/** Policy rule label when the segment is policy-classified */
 	readonly rule?: string;
 }
@@ -15,16 +17,22 @@ export interface SegmentContext {
 export interface TranslatableSegment {
 	/** Stable segment identifier used in LLM payloads and reinsertion */
 	readonly id: string;
+
 	/** mdast path string locating the segment in the document */
 	readonly path: string;
+
 	/** Whether the segment is translated, preserved verbatim, or policy-handled */
 	readonly kind: SegmentKind;
+
 	/** Source markdown substring for this segment */
 	readonly sourceText: string;
+
 	/** Inclusive start byte offset in the document body */
 	readonly start: number;
+
 	/** Exclusive end byte offset in the document body */
 	readonly end: number;
+
 	/** Optional heading, fence, or policy metadata for prompting */
 	readonly context?: SegmentContext;
 }
@@ -33,6 +41,7 @@ export interface TranslatableSegment {
 export interface BodySegmentExtractionResult {
 	/** Extracted translatable segments from the body */
 	readonly segments: readonly TranslatableSegment[];
+
 	/** Non-fatal parser warnings collected during extraction */
 	readonly parseWarnings: readonly string[];
 }
@@ -41,12 +50,16 @@ export interface BodySegmentExtractionResult {
 export interface SegmentExtractionResult {
 	/** Extracted translatable segments from the full document */
 	readonly segments: readonly TranslatableSegment[];
+
 	/** Raw YAML frontmatter block, including delimiters */
 	readonly frontmatterBlock: string;
+
 	/** Markdown body without frontmatter */
 	readonly body: string;
+
 	/** Non-fatal parser warnings collected during extraction */
 	readonly parseWarnings: readonly string[];
+
 	/** Parser toolchain identifier for diagnostics */
 	readonly tooling: "remark-mdx";
 }

--- a/src/app/services/translator/markdown/segments/types.ts
+++ b/src/app/services/translator/markdown/segments/types.ts
@@ -3,34 +3,51 @@ export type SegmentKind = "translate" | "preserve" | "policy";
 
 /** Optional context attached to translatable segments for future batching */
 export interface SegmentContext {
+	/** Nearest heading text when the segment sits under a heading */
 	readonly heading?: string;
+	/** Fence language tag when the segment is inside a code block */
 	readonly fenceLang?: string;
+	/** Policy rule label when the segment is policy-classified */
 	readonly rule?: string;
 }
 
 /** A single extractable region with source offsets for byte-stable reinsertion */
 export interface TranslatableSegment {
+	/** Stable segment identifier used in LLM payloads and reinsertion */
 	readonly id: string;
+	/** mdast path string locating the segment in the document */
 	readonly path: string;
+	/** Whether the segment is translated, preserved verbatim, or policy-handled */
 	readonly kind: SegmentKind;
+	/** Source markdown substring for this segment */
 	readonly sourceText: string;
+	/** Inclusive start byte offset in the document body */
 	readonly start: number;
+	/** Exclusive end byte offset in the document body */
 	readonly end: number;
+	/** Optional heading, fence, or policy metadata for prompting */
 	readonly context?: SegmentContext;
 }
 
 /** Result of walking a markdown body (no frontmatter) for translatable regions */
 export interface BodySegmentExtractionResult {
+	/** Extracted translatable segments from the body */
 	readonly segments: readonly TranslatableSegment[];
+	/** Non-fatal parser warnings collected during extraction */
 	readonly parseWarnings: readonly string[];
 }
 
 /** Result of walking a markdown document for translatable regions */
 export interface SegmentExtractionResult {
+	/** Extracted translatable segments from the full document */
 	readonly segments: readonly TranslatableSegment[];
+	/** Raw YAML frontmatter block, including delimiters */
 	readonly frontmatterBlock: string;
+	/** Markdown body without frontmatter */
 	readonly body: string;
+	/** Non-fatal parser warnings collected during extraction */
 	readonly parseWarnings: readonly string[];
+	/** Parser toolchain identifier for diagnostics */
 	readonly tooling: "remark-mdx";
 }
 

--- a/src/app/services/translator/translator-frontmatter-batch.schema.ts
+++ b/src/app/services/translator/translator-frontmatter-batch.schema.ts
@@ -41,9 +41,11 @@ export const frontmatterBatchRequestEnvelopeSchema = z.object({
 
 /** Allowed frontmatter field keys in a batched description translation request */
 export type FrontmatterBatchFieldKey = z.infer<typeof frontmatterBatchFieldKeySchema>;
+
 /** LLM response envelope for a batched frontmatter description translation */
 export type FrontmatterBatchTranslationEnvelope = z.infer<
 	typeof frontmatterBatchTranslationEnvelopeSchema
 >;
+
 /** User payload envelope for a batched frontmatter description translation request */
 export type FrontmatterBatchRequestEnvelope = z.infer<typeof frontmatterBatchRequestEnvelopeSchema>;

--- a/src/app/services/translator/translator-frontmatter-batch.schema.ts
+++ b/src/app/services/translator/translator-frontmatter-batch.schema.ts
@@ -39,8 +39,11 @@ export const frontmatterBatchRequestEnvelopeSchema = z.object({
 		.length(1),
 });
 
+/** Allowed frontmatter field keys in a batched description translation request */
 export type FrontmatterBatchFieldKey = z.infer<typeof frontmatterBatchFieldKeySchema>;
+/** LLM response envelope for a batched frontmatter description translation */
 export type FrontmatterBatchTranslationEnvelope = z.infer<
 	typeof frontmatterBatchTranslationEnvelopeSchema
 >;
+/** User payload envelope for a batched frontmatter description translation request */
 export type FrontmatterBatchRequestEnvelope = z.infer<typeof frontmatterBatchRequestEnvelopeSchema>;

--- a/src/app/services/translator/translator-segment-batch.schema.ts
+++ b/src/app/services/translator/translator-segment-batch.schema.ts
@@ -23,7 +23,11 @@ export const segmentBatchTranslationEnvelopeSchema = z.object({
 	items: z.array(segmentBatchTranslationItemSchema).min(1),
 });
 
+/** One segment in a batched prose translation LLM request */
 export type SegmentBatchRequestItem = z.infer<typeof segmentBatchRequestItemSchema>;
+/** User payload envelope for a segment batch translation request */
 export type SegmentBatchRequestEnvelope = z.infer<typeof segmentBatchRequestEnvelopeSchema>;
+/** One translated segment returned by the LLM in structured-output mode */
 export type SegmentBatchTranslationItem = z.infer<typeof segmentBatchTranslationItemSchema>;
+/** LLM response envelope for a batched prose segment translation */
 export type SegmentBatchTranslationEnvelope = z.infer<typeof segmentBatchTranslationEnvelopeSchema>;

--- a/src/app/services/translator/translator-segment-batch.schema.ts
+++ b/src/app/services/translator/translator-segment-batch.schema.ts
@@ -25,9 +25,12 @@ export const segmentBatchTranslationEnvelopeSchema = z.object({
 
 /** One segment in a batched prose translation LLM request */
 export type SegmentBatchRequestItem = z.infer<typeof segmentBatchRequestItemSchema>;
+
 /** User payload envelope for a segment batch translation request */
 export type SegmentBatchRequestEnvelope = z.infer<typeof segmentBatchRequestEnvelopeSchema>;
+
 /** One translated segment returned by the LLM in structured-output mode */
 export type SegmentBatchTranslationItem = z.infer<typeof segmentBatchTranslationItemSchema>;
+
 /** LLM response envelope for a batched prose segment translation */
 export type SegmentBatchTranslationEnvelope = z.infer<typeof segmentBatchTranslationEnvelopeSchema>;

--- a/src/app/services/translator/translator.constants.ts
+++ b/src/app/services/translator/translator.constants.ts
@@ -2,7 +2,7 @@
 export const LLM_TEMPERATURE = 0.1;
 
 /** Maximum tokens for connectivity test API call */
-export const CONNECTIVITY_TEST_MAX_TOKENS = 5;
+export const CONNECTIVITY_TEST_MAX_TOKENS = 32;
 
 /** Maximum prose segments packed into one segment-batch LLM request */
 export const SEGMENT_BATCH_MAX_ITEMS_PER_BATCH = 20;

--- a/src/app/services/translator/translator.service.ts
+++ b/src/app/services/translator/translator.service.ts
@@ -261,6 +261,14 @@ export class TranslatorService {
 	 * ```
 	 */
 	public async testConnectivity(): Promise<void> {
+		this.logger.info(
+			{
+				model: this.model,
+				llmApiBaseUrl: env.LLM_API_BASE_URL,
+			},
+			"Testing LLM API connectivity",
+		);
+
 		const response = await this.openai.chat.completions.create({
 			model: this.model,
 			messages: [{ role: "user", content: "ping" }],

--- a/src/app/services/translator/translator.service.ts
+++ b/src/app/services/translator/translator.service.ts
@@ -262,10 +262,7 @@ export class TranslatorService {
 	 */
 	public async testConnectivity(): Promise<void> {
 		this.logger.info(
-			{
-				model: this.model,
-				llmApiBaseUrl: env.LLM_API_BASE_URL,
-			},
+			{ model: this.model, llmApiBaseUrl: env.LLM_API_BASE_URL },
 			"Testing LLM API connectivity",
 		);
 

--- a/src/app/services/translator/validation/analyzers/advisory-style.analyzer.ts
+++ b/src/app/services/translator/validation/analyzers/advisory-style.analyzer.ts
@@ -4,10 +4,13 @@ import { MARKDOWN_REGEXES } from "../../markdown/markdown.regexes";
 export interface MdxSpacingViolation {
 	/** Human-readable label for the spacing pattern that matched */
 	readonly label: string;
+
 	/** First line number where the regression starts */
 	readonly startLine: number;
+
 	/** Last line number where the regression ends */
 	readonly endLine: number;
+
 	/** Markdown excerpt covering the matched region */
 	readonly excerpt: string;
 }
@@ -16,6 +19,7 @@ export interface MdxSpacingViolation {
 export interface SentenceCaseHeadingViolation {
 	/** One-based line number of the heading */
 	readonly lineNumber: number;
+
 	/** Full heading line text */
 	readonly line: string;
 }
@@ -24,6 +28,7 @@ export interface SentenceCaseHeadingViolation {
 export interface ExtraMarkdownLinkViolation {
 	/** Link destination URL introduced in the translation */
 	readonly url: string;
+
 	/** One-based line number where the extra link appears */
 	readonly lineNumber: number;
 }

--- a/src/app/services/translator/validation/analyzers/advisory-style.analyzer.ts
+++ b/src/app/services/translator/validation/analyzers/advisory-style.analyzer.ts
@@ -2,21 +2,29 @@ import { MARKDOWN_REGEXES } from "../../markdown/markdown.regexes";
 
 /** One MDX spacing regression with document location */
 export interface MdxSpacingViolation {
+	/** Human-readable label for the spacing pattern that matched */
 	readonly label: string;
+	/** First line number where the regression starts */
 	readonly startLine: number;
+	/** Last line number where the regression ends */
 	readonly endLine: number;
+	/** Markdown excerpt covering the matched region */
 	readonly excerpt: string;
 }
 
 /** One sentence-case heading regression with document location */
 export interface SentenceCaseHeadingViolation {
+	/** One-based line number of the heading */
 	readonly lineNumber: number;
+	/** Full heading line text */
 	readonly line: string;
 }
 
 /** One extra markdown link URL with document location */
 export interface ExtraMarkdownLinkViolation {
+	/** Link destination URL introduced in the translation */
 	readonly url: string;
+	/** One-based line number where the extra link appears */
 	readonly lineNumber: number;
 }
 

--- a/src/app/services/translator/validation/guards/frontmatter-preserved.guard.ts
+++ b/src/app/services/translator/validation/guards/frontmatter-preserved.guard.ts
@@ -5,6 +5,7 @@ import { POST_TRANSLATION_GUARD_IDS } from "../validation.constants";
 
 /** Frontmatter block dropped from a translation that had YAML frontmatter in the source */
 export interface FrontmatterPreservedViolation {
+	/** Character length of the source frontmatter block that was removed */
 	readonly sourceFrontmatterBlockLength: number;
 }
 

--- a/src/app/services/translator/validation/guards/headings-preserved.guard.ts
+++ b/src/app/services/translator/validation/guards/headings-preserved.guard.ts
@@ -7,7 +7,9 @@ const FIRST_HEADING_LINE = /^#{1,6}\s.+$/m;
 
 /** Every markdown heading removed from a translation that had headings in the source */
 export interface HeadingsPreservedViolation {
+	/** Text of the first heading removed from the source */
 	readonly firstHeadingText: string;
+	/** Character offset of the first removed heading in the source */
 	readonly firstHeadingOffset: number;
 }
 

--- a/src/app/services/translator/validation/guards/headings-preserved.guard.ts
+++ b/src/app/services/translator/validation/guards/headings-preserved.guard.ts
@@ -9,6 +9,7 @@ const FIRST_HEADING_LINE = /^#{1,6}\s.+$/m;
 export interface HeadingsPreservedViolation {
 	/** Text of the first heading removed from the source */
 	readonly firstHeadingText: string;
+
 	/** Character offset of the first removed heading in the source */
 	readonly firstHeadingOffset: number;
 }

--- a/src/app/utils/github-url.util.ts
+++ b/src/app/utils/github-url.util.ts
@@ -9,6 +9,7 @@ import { env } from "@/app/schemas/env.schema";
 /** Path segment GitHub uses for the issue template picker */
 const ISSUE_CHOOSER_PATH = "/issues/new/choose" as const;
 
+/** Inputs for building the runner issue-chooser URL */
 export interface RunnerIssueChooserUrlParams {
 	/** Value of `GITHUB_SERVER_URL` when present */
 	readonly githubServerUrl: string | undefined;

--- a/src/app/utils/llm-rate-limit.util.ts
+++ b/src/app/utils/llm-rate-limit.util.ts
@@ -1,6 +1,7 @@
 import { StatusCodes } from "http-status-codes";
 
 import { MS_PER_SECOND } from "@/app/constants";
+import { flattenOpenAiStyleErrorPayload } from "@/shared/errors/";
 
 /** Extra wait after `x-ratelimit-reset` to absorb clock skew and provider propagation delay */
 const RATE_LIMIT_RESET_BUFFER_MS = 750;
@@ -29,42 +30,6 @@ function isOpenAiCompatible429Error(
 		"message" in error &&
 		typeof (error as { message: unknown }).message === "string"
 	);
-}
-
-/**
- * Flattens nested OpenAI-style error payloads into searchable text for quota heuristics.
- *
- * @param value The nested `error` field from an OpenAI-compatible API error, when present
- *
- * @returns Concatenated string fragments, or an empty string when nothing useful is present
- */
-function flattenOpenAiStyleErrorPayload(value: unknown): string {
-	if (value === null || value === undefined) return "";
-
-	if (typeof value === "string") return value;
-
-	if (typeof value === "number" || typeof value === "boolean") return String(value);
-
-	if (typeof value === "object") {
-		const record = value as { message?: unknown; error?: unknown };
-
-		if (typeof record.message === "string" && record.message.trim().length > 0) {
-			return record.message;
-		}
-
-		if (record.error !== undefined) {
-			const nested = flattenOpenAiStyleErrorPayload(record.error);
-			if (nested.length > 0) return nested;
-		}
-
-		try {
-			return JSON.stringify(value);
-		} catch {
-			return "";
-		}
-	}
-
-	return "";
 }
 
 /**

--- a/src/app/utils/markdown-verbatim-fences.util.ts
+++ b/src/app/utils/markdown-verbatim-fences.util.ts
@@ -11,6 +11,7 @@ const FENCE_OPEN_LINE = /(^|\r?\n)([ \t]{0,3})(`{3,})([^\n\r]*)\r?\n/g;
 function closingFenceLinePattern(tickLength: number): RegExp {
 	return new RegExp(`^[ \\t]{0,3}\`{${tickLength},}\\s*$`);
 }
+
 /**
  * Finds the exclusive end index after a valid closing fence line, or `null` if none before EOF.
  *

--- a/src/app/utils/translation-cli.util.ts
+++ b/src/app/utils/translation-cli.util.ts
@@ -76,6 +76,7 @@ function collectRepeatedTranslationFilePaths(rawArgs: string[]) {
 
 	return paths;
 }
+
 /**
  * Applies translation workflow CLI flags to `import.meta.env` before runtime env validation runs.
  *

--- a/src/ci/actions/smoke.ts
+++ b/src/ci/actions/smoke.ts
@@ -25,11 +25,15 @@ import "@/app/utils/bootstrap-cli-overrides.util";
 
 import { defineCommand, runCommand } from "citty";
 
+import { env } from "@/app/utils/";
 import { isSmokeProfileId, run, runSucceeded, SmokeProfile } from "@/ci/services/smoke";
 import { handleTopLevelError } from "@/shared/errors/";
 import { createLogger } from "@/shared/utils/create-logger.util";
 
-const logger = createLogger({ level: "info", logToConsole: true }).child({
+const logger = createLogger({
+	level: env.LOG_LEVEL,
+	logToConsole: env.LOG_TO_CONSOLE,
+}).child({
 	component: "smoke",
 });
 

--- a/src/ci/schemas/env.schema.ts
+++ b/src/ci/schemas/env.schema.ts
@@ -74,13 +74,18 @@ export function getCiWorkflowOutputEnv() {
 
 /** Validated GitHub Actions context for poll/resolve scripts */
 export interface CiScriptContext {
+	/** GitHub token for Octokit in CI scripts */
 	ghToken: string;
+	/** Filesystem path to the `GITHUB_OUTPUT` file */
 	githubOutputPath: string;
+	/** Parsed `GITHUB_REPOSITORY` owner and repo name */
 	repository: {
 		owner: string;
 		repo: string;
 	};
+	/** Raw `owner/repo` slug from `GITHUB_REPOSITORY` */
 	repositorySlug: string;
+	/** Fork owner resolved for matrix and SHA variable I/O */
 	forkOwner: string;
 }
 

--- a/src/ci/schemas/env.schema.ts
+++ b/src/ci/schemas/env.schema.ts
@@ -76,15 +76,19 @@ export function getCiWorkflowOutputEnv() {
 export interface CiScriptContext {
 	/** GitHub token for Octokit in CI scripts */
 	ghToken: string;
+
 	/** Filesystem path to the `GITHUB_OUTPUT` file */
 	githubOutputPath: string;
+
 	/** Parsed `GITHUB_REPOSITORY` owner and repo name */
 	repository: {
 		owner: string;
 		repo: string;
 	};
+
 	/** Raw `owner/repo` slug from `GITHUB_REPOSITORY` */
 	repositorySlug: string;
+
 	/** Fork owner resolved for matrix and SHA variable I/O */
 	forkOwner: string;
 }

--- a/src/ci/services/smoke/runner.ts
+++ b/src/ci/services/smoke/runner.ts
@@ -44,7 +44,10 @@ export interface SmokeRunOptions {
 	artifactDir?: string;
 }
 
-const logger = createLogger({ level: "info", logToConsole: true }).child({
+const logger = createLogger({
+	level: env.LOG_LEVEL,
+	logToConsole: env.LOG_TO_CONSOLE,
+}).child({
 	component: "smoke-runner",
 });
 
@@ -125,6 +128,9 @@ export async function run(options: SmokeRunOptions) {
 	logger.info(
 		{
 			model: env.LLM_MODEL,
+			llmApiBaseUrl: env.LLM_API_BASE_URL,
+			nodeEnv: env.NODE_ENV,
+			logLevel: env.LOG_LEVEL,
 			profile: options.profile,
 			artifactDir: artifactDirRelative,
 			files: integrationFiles.map((file) => file.treeItem.path),

--- a/src/ci/services/upstream/types.ts
+++ b/src/ci/services/upstream/types.ts
@@ -18,12 +18,16 @@ export const upstreamLocalesFileSchema = z.array(upstreamLocaleConfigSchema).min
 
 /** One GitHub Actions matrix row for the translation workflow job. */
 export interface TranslationMatrixEntry extends UpstreamLocaleConfig {
+	/** Resolved fork owner for this locale row */
 	fork_owner: string;
+	/** Stored upstream default-branch SHA for change detection */
 	upstream_sha: string;
 }
 
 /** Result of comparing upstream default-branch tips to stored repository variables. */
 export interface UpstreamPollResult {
+	/** Whether any locale upstream tip differs from its stored SHA */
 	hasChanges: boolean;
+	/** Matrix rows to dispatch when {@link UpstreamPollResult.hasChanges} is true */
 	matrix: TranslationMatrixEntry[];
 }

--- a/src/ci/services/upstream/types.ts
+++ b/src/ci/services/upstream/types.ts
@@ -20,6 +20,7 @@ export const upstreamLocalesFileSchema = z.array(upstreamLocaleConfigSchema).min
 export interface TranslationMatrixEntry extends UpstreamLocaleConfig {
 	/** Resolved fork owner for this locale row */
 	fork_owner: string;
+
 	/** Stored upstream default-branch SHA for change detection */
 	upstream_sha: string;
 }
@@ -28,6 +29,7 @@ export interface TranslationMatrixEntry extends UpstreamLocaleConfig {
 export interface UpstreamPollResult {
 	/** Whether any locale upstream tip differs from its stored SHA */
 	hasChanges: boolean;
+
 	/** Matrix rows to dispatch when {@link UpstreamPollResult.hasChanges} is true */
 	matrix: TranslationMatrixEntry[];
 }

--- a/src/ci/services/upstream/upstream-sha-variable.reader.ts
+++ b/src/ci/services/upstream/upstream-sha-variable.reader.ts
@@ -7,7 +7,9 @@ import { resolveUpstreamShaVariableName } from "@/ci/services/upstream/upstream-
 
 /** Repository coordinates for Actions variable API calls. */
 export interface UpstreamShaVariableRepository {
+	/** Repository owner login or organization */
 	owner: string;
+	/** Repository name without owner prefix */
 	repo: string;
 }
 

--- a/src/ci/services/upstream/upstream-sha-variable.reader.ts
+++ b/src/ci/services/upstream/upstream-sha-variable.reader.ts
@@ -9,6 +9,7 @@ import { resolveUpstreamShaVariableName } from "@/ci/services/upstream/upstream-
 export interface UpstreamShaVariableRepository {
 	/** Repository owner login or organization */
 	owner: string;
+
 	/** Repository name without owner prefix */
 	repo: string;
 }

--- a/src/ci/utils/resolve-translation-targets.util.ts
+++ b/src/ci/utils/resolve-translation-targets.util.ts
@@ -4,6 +4,7 @@ import { collectTranslationFilePaths } from "@/app/utils/parse-translation-file-
 export interface ResolvedTranslationTargets {
 	/** Trimmed manual `file_path` input for optional `--file` forwarding */
 	path: string;
+
 	/** Whether any configured target path limits the run */
 	hasTargetPaths: boolean;
 }

--- a/src/shared/clients/octokit/octokit.client.ts
+++ b/src/shared/clients/octokit/octokit.client.ts
@@ -2,16 +2,23 @@ import { Octokit } from "@octokit/rest";
 
 /** Optional Pino-style hooks for Octokit request logging */
 export interface OctokitLogHooks {
+	/** Logs debug-level Octokit messages */
 	debug: (message: string) => void;
+	/** Logs info-level Octokit messages */
 	info: (message: string) => void;
+	/** Logs warning-level Octokit messages */
 	warn: (message: string) => void;
+	/** Logs error-level Octokit messages */
 	error: (message: string) => void;
 }
 
 /** Options for {@link createOctokit} without app env or retry logic */
 export interface CreateOctokitOptions {
+	/** GitHub token or app installation token */
 	auth: string;
+	/** Per-request timeout in milliseconds */
 	requestTimeoutMs: number;
+	/** Optional Pino-compatible log hooks for Octokit */
 	log?: OctokitLogHooks;
 }
 

--- a/src/shared/clients/octokit/octokit.client.ts
+++ b/src/shared/clients/octokit/octokit.client.ts
@@ -4,10 +4,13 @@ import { Octokit } from "@octokit/rest";
 export interface OctokitLogHooks {
 	/** Logs debug-level Octokit messages */
 	debug: (message: string) => void;
+
 	/** Logs info-level Octokit messages */
 	info: (message: string) => void;
+
 	/** Logs warning-level Octokit messages */
 	warn: (message: string) => void;
+
 	/** Logs error-level Octokit messages */
 	error: (message: string) => void;
 }
@@ -16,8 +19,10 @@ export interface OctokitLogHooks {
 export interface CreateOctokitOptions {
 	/** GitHub token or app installation token */
 	auth: string;
+
 	/** Per-request timeout in milliseconds */
 	requestTimeoutMs: number;
+
 	/** Optional Pino-compatible log hooks for Octokit */
 	log?: OctokitLogHooks;
 }

--- a/src/shared/errors/error.helpers.ts
+++ b/src/shared/errors/error.helpers.ts
@@ -62,14 +62,12 @@ export function handleTopLevelError(error: unknown, logger: Logger): void {
 		return;
 	}
 
-	if (error instanceof APIError || isUncastAPIError(error)) {
+	if (isLlmApiError(error)) {
 		logger.fatal(
 			{
 				errorType: ErrorCode.OpenAIApiError,
-				statusCode: error.status,
 				message: error.message,
-				type: error.type,
-				requestId: error.requestID,
+				...toLlmApiErrorLogFields(error),
 			},
 			`LLM API error: ${error.message}`,
 		);
@@ -219,6 +217,107 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;
 }
 
+/** {@link APIError} narrowed to concrete, non-generic member types for safe field access */
+type LlmApiError = APIError<
+	number | undefined,
+	Headers | undefined,
+	Record<string, unknown> | undefined
+>;
+
+/**
+ * Narrows an unknown value to an {@link LlmApiError}, covering both real `instanceof` matches
+ * and uncast errors that cross a package boundary (see {@link isUncastAPIError}).
+ *
+ * @param error The value to check
+ *
+ * @returns `true` when `error` is an OpenAI-compatible API error
+ */
+function isLlmApiError(error: unknown): error is LlmApiError {
+	return error instanceof APIError || isUncastAPIError(error);
+}
+
+/**
+ * Flattens nested OpenAI-style error payloads into searchable text for logging and quota heuristics.
+ *
+ * @param value The nested `error` field from an OpenAI-compatible API error, when present
+ *
+ * @returns Concatenated string fragments, or an empty string when nothing useful is present
+ */
+export function flattenOpenAiStyleErrorPayload(value: unknown): string {
+	if (value === null || value === undefined) return "";
+
+	if (typeof value === "string") return value;
+
+	if (typeof value === "number" || typeof value === "boolean") return String(value);
+
+	if (typeof value === "object") {
+		const record = value as { message?: unknown; error?: unknown; metadata?: unknown };
+
+		if (typeof record.message === "string" && record.message.trim().length > 0) {
+			return record.message;
+		}
+
+		if (record.metadata !== undefined) {
+			const metadataText = flattenOpenAiStyleErrorPayload(record.metadata);
+			if (metadataText.length > 0) return metadataText;
+		}
+
+		if (record.error !== undefined) {
+			const nested = flattenOpenAiStyleErrorPayload(record.error);
+			if (nested.length > 0) return nested;
+		}
+
+		try {
+			return JSON.stringify(value);
+		} catch {
+			return "";
+		}
+	}
+
+	return "";
+}
+
+/** Log-safe fields extracted from an {@link LlmApiError}, as returned by {@link toLlmApiErrorLogFields} */
+export interface LlmApiErrorLogFields {
+	/** HTTP status from the provider response */
+	statusCode?: number;
+	/** Provider error type string when present */
+	llmErrorType?: string;
+	/** Provider request id for support correlation */
+	requestId?: string | null;
+	/** Flattened provider error message when present */
+	providerMessage?: string;
+	/** OpenRouter `metadata` payload when present */
+	providerMetadata?: Record<string, unknown>;
+}
+
+/**
+ * Returns log-safe LLM API error fields, including OpenRouter provider metadata when present.
+ *
+ * @param error Caught rejection from the OpenAI-compatible client
+ *
+ * @returns Structured fields for error/fatal logs, or an empty object for non-LLM errors
+ */
+export function toLlmApiErrorLogFields(error: unknown): LlmApiErrorLogFields {
+	if (!isLlmApiError(error)) {
+		return {};
+	}
+
+	const providerMessage = flattenOpenAiStyleErrorPayload(error.error);
+	const providerMetadata =
+		isRecord(error.error) && isRecord(error.error["metadata"]) ?
+			error.error["metadata"]
+		:	undefined;
+
+	return {
+		statusCode: error.status,
+		llmErrorType: error.type,
+		requestId: error.requestID,
+		...(providerMessage.length > 0 ? { providerMessage } : {}),
+		...(providerMetadata ? { providerMetadata } : {}),
+	};
+}
+
 /**
  * Returns log-safe fields from an error without request headers or other sensitive payloads.
  *
@@ -241,6 +340,15 @@ export function toSafeErrorLogFields(error: unknown) {
 			message: error.message,
 			name: error.name,
 			status: error.status,
+		};
+	}
+
+	if (isLlmApiError(error)) {
+		return {
+			message: error.message,
+			name: error.name,
+			status: error.status,
+			...toLlmApiErrorLogFields(error),
 		};
 	}
 

--- a/src/shared/errors/error.helpers.ts
+++ b/src/shared/errors/error.helpers.ts
@@ -237,6 +237,69 @@ function isLlmApiError(error: unknown): error is LlmApiError {
 }
 
 /**
+ * Parses a string when it looks like JSON; otherwise returns the original value.
+ *
+ * @param value Candidate JSON string or any other value
+ *
+ * @returns Parsed JSON value, or the original input when parsing does not apply
+ */
+function tryParseJsonString(value: unknown): unknown {
+	if (typeof value !== "string") {
+		return value;
+	}
+
+	const trimmed = value.trim();
+	if (trimmed.length === 0) {
+		return value;
+	}
+
+	const firstChar = trimmed.at(0);
+	if (firstChar !== "{" && firstChar !== "[") {
+		return value;
+	}
+
+	try {
+		return JSON.parse(trimmed);
+	} catch {
+		return value;
+	}
+}
+
+/**
+ * Normalizes OpenRouter provider metadata for structured logging by parsing embedded JSON `raw` payloads.
+ *
+ * @param metadata OpenRouter `metadata` object from an API error
+ *
+ * @returns Metadata with parsed `raw` and `previous_errors[].raw` values when JSON
+ */
+function normalizeProviderMetadataForLogging(
+	metadata: Record<string, unknown>,
+): Record<string, unknown> {
+	const normalized: Record<string, unknown> = { ...metadata };
+
+	if (typeof normalized["raw"] === "string") {
+		normalized["raw"] = tryParseJsonString(normalized["raw"]);
+	}
+
+	if (Array.isArray(normalized["previous_errors"])) {
+		normalized["previous_errors"] = normalized["previous_errors"].map((entry) => {
+			if (!isRecord(entry)) {
+				return entry;
+			}
+
+			const item: Record<string, unknown> = { ...entry };
+			if (typeof item["raw"] === "string") {
+				item["raw"] = tryParseJsonString(item["raw"]);
+			}
+
+			return item;
+		});
+	}
+
+	return normalized;
+}
+
+/**
  * Flattens nested OpenAI-style error payloads into searchable text for logging and quota heuristics.
  *
  * @param value The nested `error` field from an OpenAI-compatible API error, when present
@@ -258,6 +321,19 @@ export function flattenOpenAiStyleErrorPayload(value: unknown): string {
 		}
 
 		if (record.metadata !== undefined) {
+			if (isRecord(record.metadata)) {
+				const raw = record.metadata["raw"];
+				if (typeof raw === "string" && raw.trim().length > 0) {
+					const parsed = tryParseJsonString(raw);
+					const fromRaw = flattenOpenAiStyleErrorPayload(parsed);
+					if (fromRaw.length > 0) {
+						return fromRaw;
+					}
+
+					return raw;
+				}
+			}
+
 			const metadataText = flattenOpenAiStyleErrorPayload(record.metadata);
 			if (metadataText.length > 0) return metadataText;
 		}
@@ -281,12 +357,16 @@ export function flattenOpenAiStyleErrorPayload(value: unknown): string {
 export interface LlmApiErrorLogFields {
 	/** HTTP status from the provider response */
 	statusCode?: number;
+
 	/** Provider error type string when present */
 	llmErrorType?: string;
+
 	/** Provider request id for support correlation */
 	requestId?: string | null;
+
 	/** Flattened provider error message when present */
 	providerMessage?: string;
+
 	/** OpenRouter `metadata` payload when present */
 	providerMetadata?: Record<string, unknown>;
 }
@@ -306,7 +386,7 @@ export function toLlmApiErrorLogFields(error: unknown): LlmApiErrorLogFields {
 	const providerMessage = flattenOpenAiStyleErrorPayload(error.error);
 	const providerMetadata =
 		isRecord(error.error) && isRecord(error.error["metadata"]) ?
-			error.error["metadata"]
+			normalizeProviderMetadataForLogging(error.error["metadata"])
 		:	undefined;
 
 	return {

--- a/src/shared/utils/create-logger.util.ts
+++ b/src/shared/utils/create-logger.util.ts
@@ -6,8 +6,11 @@ import { nftsCompatibleDateString } from "./nfts-date.util";
 
 /** Configuration for {@link createLogger} */
 export interface CreateLoggerOptions {
+	/** Minimum Pino log level */
 	level: pino.LevelWithSilent;
+	/** Whether logs are mirrored to stdout */
 	logToConsole: boolean;
+	/** Working directory used for log file paths */
 	cwd?: string;
 }
 

--- a/src/shared/utils/create-logger.util.ts
+++ b/src/shared/utils/create-logger.util.ts
@@ -8,8 +8,10 @@ import { nftsCompatibleDateString } from "./nfts-date.util";
 export interface CreateLoggerOptions {
 	/** Minimum Pino log level */
 	level: pino.LevelWithSilent;
+
 	/** Whether logs are mirrored to stdout */
 	logToConsole: boolean;
+
 	/** Working directory used for log file paths */
 	cwd?: string;
 }

--- a/tests/errors/error.helpers.spec.ts
+++ b/tests/errors/error.helpers.spec.ts
@@ -5,12 +5,14 @@ import { AbortError } from "p-retry";
 import {
 	ApplicationError,
 	ErrorCode,
+	flattenOpenAiStyleErrorPayload,
 	getSegmentBatchSplitReason,
 	handleTopLevelError,
 	isCompletionLengthTruncationError,
 	isSegmentBatchIdMismatchError,
 	isSegmentBatchSplittableError,
 	isSegmentBatchStructuredOutputError,
+	toLlmApiErrorLogFields,
 	toSafeErrorLogFields,
 } from "@/shared/errors/";
 
@@ -68,16 +70,22 @@ describe("handleTopLevelError", () => {
 		);
 	});
 
-	test("logs APIError with LLM context", () => {
-		const fatalMock = mock(() => {
-			/* empty */
-		});
+	test("logs APIError with LLM context and provider metadata", () => {
+		const fatalMock = mock(
+			(_context: Record<string, unknown>, _message: string): void => undefined,
+		);
 		const logger = { fatal: fatalMock, child: () => ({ fatal: fatalMock }) };
 
 		const error = createOpenAIApiErrorFixture({
-			message: "Rate limit exceeded",
-			error: { type: "rate_limit_error" },
-			status: StatusCodes.TOO_MANY_REQUESTS,
+			message: "400 Provider returned error",
+			error: {
+				type: "invalid_request_error",
+				metadata: {
+					provider_name: "OpenAI",
+					raw: "Model does not support temperature",
+				},
+			},
+			status: StatusCodes.BAD_REQUEST,
 			headers: new Headers({ "x-request-id": "req-llm-456" }),
 		});
 
@@ -87,7 +95,15 @@ describe("handleTopLevelError", () => {
 		expect(fatalMock).toHaveBeenCalledWith(
 			expect.objectContaining({
 				errorType: ErrorCode.OpenAIApiError,
-				statusCode: StatusCodes.TOO_MANY_REQUESTS,
+				statusCode: StatusCodes.BAD_REQUEST,
+				providerMessage: JSON.stringify({
+					provider_name: "OpenAI",
+					raw: "Model does not support temperature",
+				}),
+				providerMetadata: {
+					provider_name: "OpenAI",
+					raw: "Model does not support temperature",
+				},
 			}),
 			expect.stringContaining("LLM API error"),
 		);
@@ -352,6 +368,29 @@ describe("toSafeErrorLogFields", () => {
 		});
 	});
 
+	test("returns provider metadata for APIError", () => {
+		const fields = toSafeErrorLogFields(
+			createOpenAIApiErrorFixture({
+				message: "400 Provider returned error",
+				status: StatusCodes.BAD_REQUEST,
+				error: {
+					metadata: {
+						provider_name: "OpenAI",
+						raw: "invalid model",
+					},
+				},
+			}),
+		);
+
+		expect(fields).toMatchObject({
+			status: StatusCodes.BAD_REQUEST,
+			providerMetadata: {
+				provider_name: "OpenAI",
+				raw: "invalid model",
+			},
+		});
+	});
+
 	test("returns status and message for Octokit RequestError without request payload", () => {
 		const fields = toSafeErrorLogFields(
 			createOctokitRequestErrorFixture({
@@ -366,5 +405,24 @@ describe("toSafeErrorLogFields", () => {
 			status: StatusCodes.FORBIDDEN,
 		});
 		expect(fields).not.toHaveProperty("request");
+	});
+});
+
+describe("flattenOpenAiStyleErrorPayload", () => {
+	test("extracts nested provider metadata raw text", () => {
+		const text = flattenOpenAiStyleErrorPayload({
+			metadata: {
+				provider_name: "OpenAI",
+				raw: "Model not found",
+			},
+		});
+
+		expect(text).toContain("Model not found");
+	});
+});
+
+describe("toLlmApiErrorLogFields", () => {
+	test("returns empty object for non-API errors", () => {
+		expect(toLlmApiErrorLogFields(new Error("network"))).toEqual({});
 	});
 });

--- a/tests/errors/error.helpers.spec.ts
+++ b/tests/errors/error.helpers.spec.ts
@@ -96,10 +96,7 @@ describe("handleTopLevelError", () => {
 			expect.objectContaining({
 				errorType: ErrorCode.OpenAIApiError,
 				statusCode: StatusCodes.BAD_REQUEST,
-				providerMessage: JSON.stringify({
-					provider_name: "OpenAI",
-					raw: "Model does not support temperature",
-				}),
+				providerMessage: "Model does not support temperature",
 				providerMetadata: {
 					provider_name: "OpenAI",
 					raw: "Model does not support temperature",
@@ -419,10 +416,82 @@ describe("flattenOpenAiStyleErrorPayload", () => {
 
 		expect(text).toContain("Model not found");
 	});
+
+	test("extracts nested error message from JSON provider metadata raw", () => {
+		const text = flattenOpenAiStyleErrorPayload({
+			metadata: {
+				provider_name: "Azure",
+				raw: JSON.stringify({
+					error: {
+						message:
+							"Invalid 'max_output_tokens': integer below minimum value. Expected a value >= 16, but got 5 instead.",
+						type: "invalid_request_error",
+						param: "max_output_tokens",
+						code: "integer_below_min_value",
+					},
+				}),
+			},
+		});
+
+		expect(text).toBe(
+			"Invalid 'max_output_tokens': integer below minimum value. Expected a value >= 16, but got 5 instead.",
+		);
+	});
 });
 
 describe("toLlmApiErrorLogFields", () => {
 	test("returns empty object for non-API errors", () => {
 		expect(toLlmApiErrorLogFields(new Error("network"))).toEqual({});
+	});
+
+	test("parses JSON provider metadata raw into structured objects", () => {
+		const fields = toLlmApiErrorLogFields(
+			createOpenAIApiErrorFixture({
+				message: "400 Provider returned error",
+				status: StatusCodes.BAD_REQUEST,
+				error: {
+					metadata: {
+						provider_name: "Azure",
+						raw: JSON.stringify({
+							error: {
+								message: "Invalid max_output_tokens",
+								code: "integer_below_min_value",
+							},
+						}),
+						previous_errors: [
+							{
+								code: 400,
+								message: "Provider returned error",
+								provider_name: "OpenAI",
+								raw: JSON.stringify({
+									error: { message: "Same upstream rejection" },
+								}),
+							},
+						],
+					},
+				},
+			}),
+		);
+
+		expect(fields.providerMessage).toBe("Invalid max_output_tokens");
+		expect(fields.providerMetadata).toEqual({
+			provider_name: "Azure",
+			raw: {
+				error: {
+					message: "Invalid max_output_tokens",
+					code: "integer_below_min_value",
+				},
+			},
+			previous_errors: [
+				{
+					code: 400,
+					message: "Provider returned error",
+					provider_name: "OpenAI",
+					raw: {
+						error: { message: "Same upstream rejection" },
+					},
+				},
+			],
+		});
 	});
 });

--- a/tests/fixtures/workflow-fixture.util.ts
+++ b/tests/fixtures/workflow-fixture.util.ts
@@ -56,6 +56,7 @@ export enum WorkflowFixturePrScenario {
 export interface WorkflowFixtureSmoke {
 	/** Pull request number returned by mocked GitHub APIs */
 	pullRequestNumber: number;
+
 	/** Scenario controlling fork content and PR validity mocks */
 	pullRequestScenario?: WorkflowFixturePrScenario;
 
@@ -72,8 +73,10 @@ export interface WorkflowFixtureSmoke {
 export type WorkflowFixtureManifestEntry = Readonly<{
 	/** Workflow fixture profile controlling discovery and smoke behavior */
 	profile?: WorkflowFixtureProfile;
+
 	/** Upstream tree metadata for one fixture markdown file */
 	tree: WorkflowFixtureTree;
+
 	/** Optional smoke-only GitHub mock overrides */
 	smoke?: Partial<WorkflowFixtureSmoke>;
 }>;
@@ -87,8 +90,10 @@ export type WorkflowFixtureManifestEntry = Readonly<{
 export type WorkflowFixtureFile = Readonly<{
 	/** Patched repository tree item for the fixture candidate */
 	treeItem: PatchedRepositoryTreeItem;
+
 	/** Upstream markdown blob loaded from the fixture file */
 	blob: RepositoryMarkdownBlob;
+
 	/** Smoke-only GitHub mock metadata for artifact capture */
 	smoke: WorkflowFixtureSmoke;
 }>;

--- a/tests/fixtures/workflow-fixture.util.ts
+++ b/tests/fixtures/workflow-fixture.util.ts
@@ -54,7 +54,9 @@ export enum WorkflowFixturePrScenario {
 
 /** Mock GitHub knobs for smoke and integration artifact capture */
 export interface WorkflowFixtureSmoke {
+	/** Pull request number returned by mocked GitHub APIs */
 	pullRequestNumber: number;
+	/** Scenario controlling fork content and PR validity mocks */
 	pullRequestScenario?: WorkflowFixturePrScenario;
 
 	/** Fork branch markdown returned by `getForkFileContentAtBranch` for existing-PR scenarios */
@@ -68,8 +70,11 @@ export interface WorkflowFixtureSmoke {
  * `filename`, which the runner derives from `path`). Markdown body bytes are loaded from disk.
  */
 export type WorkflowFixtureManifestEntry = Readonly<{
+	/** Workflow fixture profile controlling discovery and smoke behavior */
 	profile?: WorkflowFixtureProfile;
+	/** Upstream tree metadata for one fixture markdown file */
 	tree: WorkflowFixtureTree;
+	/** Optional smoke-only GitHub mock overrides */
 	smoke?: Partial<WorkflowFixtureSmoke>;
 }>;
 
@@ -80,8 +85,11 @@ export type WorkflowFixtureManifestEntry = Readonly<{
  * {@link GitHubService.getFile} (`RepositoryMarkdownBlob`) before translation starts.
  */
 export type WorkflowFixtureFile = Readonly<{
+	/** Patched repository tree item for the fixture candidate */
 	treeItem: PatchedRepositoryTreeItem;
+	/** Upstream markdown blob loaded from the fixture file */
 	blob: RepositoryMarkdownBlob;
+	/** Smoke-only GitHub mock metadata for artifact capture */
 	smoke: WorkflowFixtureSmoke;
 }>;
 

--- a/tests/helpers/runner-dependencies.harness.ts
+++ b/tests/helpers/runner-dependencies.harness.ts
@@ -21,12 +21,16 @@ import {
 export interface MockRunnerServiceDependencies {
 	/** Mock GitHub service injected into the runner */
 	github?: MockGitHubService;
+
 	/** Mock translator service injected into the runner */
 	translator?: MockTranslatorService;
+
 	/** Mock language cache service injected into the runner */
 	languageCache?: MockLanguageCacheService;
+
 	/** Locale service injected into the runner */
 	locale?: LocaleService;
+
 	/** Mock language detector service injected into the runner */
 	languageDetector?: MockLanguageDetectorService;
 }

--- a/tests/helpers/runner-dependencies.harness.ts
+++ b/tests/helpers/runner-dependencies.harness.ts
@@ -19,10 +19,15 @@ import {
 
 /** Mock dependency overrides accepted by runner workflow unit test harnesses */
 export interface MockRunnerServiceDependencies {
+	/** Mock GitHub service injected into the runner */
 	github?: MockGitHubService;
+	/** Mock translator service injected into the runner */
 	translator?: MockTranslatorService;
+	/** Mock language cache service injected into the runner */
 	languageCache?: MockLanguageCacheService;
+	/** Locale service injected into the runner */
 	locale?: LocaleService;
+	/** Mock language detector service injected into the runner */
 	languageDetector?: MockLanguageDetectorService;
 }
 

--- a/tests/helpers/segment-guard-simulation.util.ts
+++ b/tests/helpers/segment-guard-simulation.util.ts
@@ -11,8 +11,10 @@ import { collectPostTranslationValidationIssues } from "@/app/services/translato
 export interface GuardSimulationRow {
 	/** Post-translation guard identifier under test */
 	readonly guardId: string;
+
 	/** Whether the guard fires on a deliberately bad full-body translation */
 	readonly firesOnSimulatedBadFullBody: boolean;
+
 	/** Whether segment freeze prevents the guard from firing */
 	readonly preventedBySegmentFreeze: boolean;
 }

--- a/tests/helpers/segment-guard-simulation.util.ts
+++ b/tests/helpers/segment-guard-simulation.util.ts
@@ -9,8 +9,11 @@ import { collectPostTranslationValidationIssues } from "@/app/services/translato
 
 /** One row in the guard simulation table for a fixture */
 export interface GuardSimulationRow {
+	/** Post-translation guard identifier under test */
 	readonly guardId: string;
+	/** Whether the guard fires on a deliberately bad full-body translation */
 	readonly firesOnSimulatedBadFullBody: boolean;
+	/** Whether segment freeze prevents the guard from firing */
 	readonly preventedBySegmentFreeze: boolean;
 }
 

--- a/tests/services/locale/locale.service.spec.ts
+++ b/tests/services/locale/locale.service.spec.ts
@@ -290,6 +290,26 @@ describe("ptBrLocale.pullRequest.body", () => {
 	});
 });
 
+describe("ruLocale.rules", () => {
+	test("should include semantic calque avoidance rules", () => {
+		const { specific } = ruLocale.rules;
+
+		expect(specific).toContain("SEMANTIC TRANSLATION (avoid calques)");
+		expect(specific).toContain("null prototype");
+		expect(specific).toContain("client-marked code");
+		expect(specific).toContain("tree graph");
+		expect(specific).toContain("As dependencies of ComponentA");
+	});
+
+	test("should include Russian guideline rules from maintainer feedback", () => {
+		const { specific } = ruLocale.rules;
+
+		expect(specific).toContain("бандлер");
+		expect(specific).toContain("серверные компоненты");
+		expect(specific).toContain("developer.mozilla.org/ru/docs");
+	});
+});
+
 describe("ruLocale.pullRequest.body", () => {
 	const buildPullRequestBody = ruLocale.pullRequest.body;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly logging, lint/docs, and a small connectivity constant; no auth or translation logic changes beyond safer startup pings.
> 
> **Overview**
> **Release 0.2.12** bumps `package.json` and documents the slice in `CHANGELOG.md`.
> 
> **LLM connectivity and observability:** The pre-run connectivity ping now requests **32** max output tokens (was **5**) so providers with a ≥16 minimum no longer fail startup. `TranslatorService.testConnectivity()` logs model and base URL before the ping; smoke runner startup logs add the same plus `NODE_ENV` / `LOG_LEVEL`. CI smoke logging respects validated `LOG_LEVEL` and `LOG_TO_CONSOLE` instead of hard-coded info + console.
> 
> **Error logging:** Shared helpers (`flattenOpenAiStyleErrorPayload`, `toLlmApiErrorLogFields`) centralize OpenAI-compatible error flattening; OpenRouter `metadata.raw` JSON is parsed for logs. Fatal LLM errors and `toSafeErrorLogFields` / runner workflow failures emit structured `providerMessage` and `providerMetadata` instead of raw JSON blobs. Rate-limit utilities import the shared flattener (local duplicate removed).
> 
> **Docs lint:** ESLint adds `jsdoc/lines-before-block`, `jsdoc/require-jsdoc`, and `jsdoc/require-description` on public interfaces/types/properties, driving widespread JSDoc additions and blank lines before blocks.
> 
> **CI copy:** Workflow input descriptions are shortened; smoke workflow display name is `Smoke Workflow`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 001be93fb36aee98e24b944790eafca2ad84ff68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->